### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Qiskit/qiskit-primitives


### PR DESCRIPTION
## Summary

This PR adds a CODEOWNERS file and lists the primitives team as the codeowners.

## Details and comments
