### PR TITLE
Add a function to find instructions with unique boxes

### DIFF
--- a/samplomatic/transpiler/passes/add_inject_noise.py
+++ b/samplomatic/transpiler/passes/add_inject_noise.py
@@ -70,8 +70,9 @@ class AddInjectNoise(TransformationPass):
         )
 
         for node in dag.op_nodes():
-            if node.op.name == "box" and get_annotation(node.op, Twirl):
-                undressed_box = undress_box(node.op, Twirl)
+            if node.op.name == "box" and (twirl := get_annotation(node.op, Twirl)):
+                undressed_box = undress_box(node.op)
+                undressed_box.annotations = [twirl]
                 if undressed_box.body.num_nonlocal_gates() == 0:
                     # Skip boxes that do not contain entanglers
                     continue

--- a/samplomatic/utils/__init__.py
+++ b/samplomatic/utils/__init__.py
@@ -13,5 +13,6 @@
 """Utility functions."""
 
 from .box_key import BoxKey
+from .find_unique_box_instructions import find_unique_box_instructions
 from .get_annotation import get_annotation
 from .undress_box import undress_box

--- a/samplomatic/utils/find_unique_box_instructions.py
+++ b/samplomatic/utils/find_unique_box_instructions.py
@@ -1,0 +1,92 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""find_unique_box_instructions"""
+
+from collections.abc import Callable, Iterable
+
+from qiskit.circuit import Annotation, CircuitInstruction
+
+from ..annotations import InjectNoise, Twirl
+from .box_key import BoxKey
+from .undress_box import undress_box
+
+
+def default_normalize_annotations(annotations: Iterable[Annotation]) -> list[Annotation]:
+    """
+    Normalizes annotations by discarding every annotation not of type ``Twirl`` and ``InjectNoise``.
+
+    For ``Twirl`` annotations, it creates a new instance with the same group, dressing, and
+    decomposition. For ``InjectNoise`` annotations, it creates a new instance with the same
+    ``ref`` and default ``modifier_ref``.
+
+    Args:
+        annotations: The annotation to normalize.
+
+    Returns:
+        The normalized annotations.
+    """
+    normalized_annotations = []
+    for annot in annotations:
+        if isinstance(annot, Twirl):
+            normalized_annotations.append(
+                Twirl(group=annot.group, dressing=annot.dressing, decomposition=annot.decomposition)
+            )
+        elif isinstance(annot, InjectNoise):
+            normalized_annotations.append(InjectNoise(ref=annot.ref))
+    return normalized_annotations
+
+
+def find_unique_box_instructions(
+    instructions: Iterable[CircuitInstruction],
+    undress_boxes: bool = True,
+    normalize_annotations: Callable[[Iterable[Annotation]], list[Annotation]] | None = None,
+) -> list[CircuitInstruction]:
+    """
+    Return instructions that contains unique boxes.
+
+    This function iterates through the given ``instructions``, identifying those that contain a
+    :class:`.~BoxOp` operation and comparing them based on their content and annotations. It
+    returns a list of instructions that contains unique boxes. Optionally, it allows undressing
+    the boxes before comparison, as well as normalizing their annotations to ignore irrelevant
+    fields.
+
+    Args:
+        instructions: The instructions to iterate through.
+        undress_boxes: Whether to call the :meth:`~.undress_box` method on each box before
+            comparison.
+        normalize_annotations: A callable mapping annotations to annotations, which is applied to
+            the annotations of each box before comparison. If ``None``, it discards every
+            annotation that is not of type ``Twirl`` and ``InjectNoise``, and it resets the
+            ``modifier_ref`` field of ``InjectNoise`` annotations to the default value.
+
+    Returns:
+        A list of unique instructions.
+    """
+    normalize_annotations = normalize_annotations or default_normalize_annotations
+
+    instr_dict: dict[BoxKey, CircuitInstruction] = {}
+    for instr in instructions:
+        if instr.name != "box":
+            continue
+
+        box = (
+            undress_box(instr.operation)
+            if undress_boxes
+            else instr.operation.copy()  # Copy to avoid modifying the original box
+        )
+        box.annotations = normalize_annotations(instr.operation.annotations)
+
+        new_instr = CircuitInstruction(box, instr.qubits, instr.clbits)
+        instr_dict[BoxKey(new_instr)] = new_instr
+
+    return list(instr_dict.values())

--- a/test/unit/test_utils/test_box_key.py
+++ b/test/unit/test_utils/test_box_key.py
@@ -17,7 +17,6 @@ from itertools import combinations
 
 import pytest
 from qiskit.circuit import (
-    Annotation,
     BoxOp,
     CircuitInstruction,
     Parameter,
@@ -153,10 +152,6 @@ def test_symmetric_gates():
 
 def test_boxes_with_annotations():
     """Test boxes with annotations."""
-
-    class MyAnnotation(Annotation):
-        pass
-
     body = QuantumCircuit(2)
     body.h(0)
     body.h(1)
@@ -165,11 +160,6 @@ def test_boxes_with_annotations():
     qubits = body.qubits
 
     instr = CircuitInstruction(BoxOp(body), qubits)
-    instr_custom_annotation = CircuitInstruction(BoxOp(body, annotations=[MyAnnotation()]), qubits)
-    instr_twirl = CircuitInstruction(BoxOp(body, annotations=[Twirl()]), qubits)
-    instr_right_twirl = CircuitInstruction(
-        BoxOp(body, annotations=[Twirl(dressing="right")]), qubits
-    )
     instr_twirl_inject = CircuitInstruction(
         BoxOp(body, annotations=[Twirl(), InjectNoise("ref")]), qubits
     )
@@ -177,7 +167,6 @@ def test_boxes_with_annotations():
         BoxOp(body, annotations=[InjectNoise("ref"), Twirl()]), qubits
     )
 
-    assert BoxKey(instr) != BoxKey(instr_custom_annotation)
-    assert BoxKey(instr) != BoxKey(instr_twirl)
-    assert BoxKey(instr_twirl) != BoxKey(instr_right_twirl)
-    assert BoxKey(instr_twirl_inject) == BoxKey(instr_inject_twirl)
+    assert BoxKey(instr) != BoxKey(instr_twirl_inject)
+    assert BoxKey(instr) != BoxKey(instr_inject_twirl)
+    assert BoxKey(instr_inject_twirl) == BoxKey(instr_twirl_inject)

--- a/test/unit/test_utils/test_find_unique_box_instructions.py
+++ b/test/unit/test_utils/test_find_unique_box_instructions.py
@@ -1,0 +1,182 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for `find_unique_box_instructions`"""
+
+from qiskit.circuit import BoxOp, CircuitInstruction, Parameter, QuantumCircuit
+from qiskit.circuit.library import CXGate
+
+from samplomatic.annotations import InjectNoise, Twirl
+from samplomatic.utils import BoxKey, find_unique_box_instructions, undress_box
+
+
+def test_undress_boxes_is_true():
+    """Test ``find_unique_box_instructions`` when ``undress_boxes`` is ``True``."""
+    body = QuantumCircuit(4)
+    body.h(0)
+    body.cz(0, 1)
+    annotations = [Twirl(decomposition="rzrx")]
+    instr0 = CircuitInstruction(BoxOp(body, annotations=annotations), body.qubits)
+
+    body = QuantumCircuit(4)
+    body.y(0)
+    body.t(0)
+    body.s(2)
+    body.cz(0, 1)
+    annotations = [Twirl(decomposition="rzrx")]
+    instr1 = CircuitInstruction(BoxOp(body, annotations=annotations), body.qubits)
+
+    body = QuantumCircuit(4)
+    body.cz(1, 0)  # qubits in reverse order
+    body.rz(Parameter("phi"), 0)
+    annotations = [Twirl(dressing="right")]
+    instr2 = CircuitInstruction(BoxOp(body, annotations=annotations), body.qubits)
+
+    body = QuantumCircuit(2)
+    body.cz(0, 1)
+    body.rz(Parameter("phi"), 0)
+    annotations = [Twirl()]
+    instr3 = CircuitInstruction(BoxOp(body, annotations=annotations), body.qubits)
+
+    unique_instructions = find_unique_box_instructions([instr0, instr1, instr2, instr3])
+    assert len(unique_instructions) == 3
+
+    expected_instr0 = CircuitInstruction(undress_box(instr0.operation), instr0.qubits)
+    expected_instr0.operation.annotations = [Twirl(decomposition="rzrx")]
+    expected_instr1 = CircuitInstruction(undress_box(instr2.operation), instr2.qubits)
+    expected_instr1.operation.annotations = [Twirl(dressing="right")]
+    expected_instr2 = CircuitInstruction(undress_box(instr3.operation), instr3.qubits)
+    expected_instr2.operation.annotations = [Twirl()]
+
+    assert BoxKey(unique_instructions[0]) == BoxKey(expected_instr0)
+    assert BoxKey(unique_instructions[1]) == BoxKey(expected_instr1)
+    assert BoxKey(unique_instructions[2]) == BoxKey(expected_instr2)
+
+
+def test_undress_boxes_is_false():
+    """Test ``find_unique_box_instructions`` when ``undress_boxes`` is ``False``."""
+    body = QuantumCircuit(4)
+    body.h(0)
+    body.cz(0, 1)
+    annotations = [Twirl(decomposition="rzrx")]
+    instr0 = CircuitInstruction(BoxOp(body, annotations=annotations), body.qubits)
+
+    body = QuantumCircuit(4)
+    body.y(0)
+    body.t(0)
+    body.s(2)
+    body.cz(0, 1)
+    annotations = [Twirl(decomposition="rzrx")]
+    instr1 = CircuitInstruction(BoxOp(body, annotations=annotations), body.qubits)
+
+    body = QuantumCircuit(4)
+    body.cz(1, 0)  # qubits in reverse order
+    body.rz(Parameter("phi"), 0)
+    annotations = [Twirl(dressing="right")]
+    instr2 = CircuitInstruction(BoxOp(body, annotations=annotations), body.qubits)
+
+    body = QuantumCircuit(2)
+    body.cz(0, 1)
+    body.rz(Parameter("phi"), 0)
+    annotations = [Twirl()]
+    instr3 = CircuitInstruction(BoxOp(body, annotations=annotations), body.qubits)
+
+    instructions = [instr0, instr1, instr2, instr3]
+    unique_instructions = find_unique_box_instructions(
+        instructions,
+        undress_boxes=False,
+        normalize_annotations=lambda _: [],
+    )
+    assert len(unique_instructions) == 4
+
+    for instr, unique_instr in zip(instructions, unique_instructions):
+        expected_instr = instr
+        expected_instr.operation.annotations = []
+        assert BoxKey(expected_instr) == BoxKey(unique_instr)
+
+
+def test_normalize_annotations():
+    """Test the ``normalize_annotations`` argument of ``find_unique_box_instructions``."""
+    body = QuantumCircuit(4)
+    body.h(0)
+    body.cz(0, 1)
+    annotations = [Twirl(decomposition="rzrx"), InjectNoise("ref", "mod_ref")]
+    instr0 = CircuitInstruction(BoxOp(body, annotations=annotations), body.qubits)
+
+    body = QuantumCircuit(4)
+    body.y(0)
+    body.t(0)
+    body.s(2)
+    body.cz(0, 1)
+    annotations = [Twirl(decomposition="rzrx"), InjectNoise("ref", "another_modifier_ref")]
+    instr1 = CircuitInstruction(BoxOp(body, annotations=annotations), body.qubits)
+
+    body = QuantumCircuit(4)
+    body.rz(Parameter("phi"), 0)
+    body.cz(1, 0)
+    annotations = [Twirl()]
+    instr2 = CircuitInstruction(BoxOp(body, annotations=annotations), body.qubits)
+
+    instructions = [instr0, instr1, instr2]
+
+    unique_instructions = find_unique_box_instructions(
+        instructions,
+        normalize_annotations=lambda annotations: [
+            Twirl(dressing=annot.dressing) for annot in annotations if isinstance(annot, Twirl)
+        ],
+    )
+    assert len(unique_instructions) == 1
+    assert unique_instructions[0].operation.annotations == [Twirl()]
+
+    unique_instructions = find_unique_box_instructions(
+        instructions,
+        normalize_annotations=lambda annotations: [
+            Twirl(decomposition=annot.decomposition)
+            for annot in annotations
+            if isinstance(annot, Twirl)
+        ],
+    )
+    assert len(unique_instructions) == 2
+    assert unique_instructions[0].operation.annotations == [Twirl(decomposition="rzrx")]
+    assert unique_instructions[1].operation.annotations == [Twirl()]
+
+    unique_instructions = find_unique_box_instructions(
+        instructions,
+        normalize_annotations=lambda annotations: [
+            InjectNoise(annot.ref) for annot in annotations if isinstance(annot, InjectNoise)
+        ],
+    )
+    assert len(unique_instructions) == 2
+    assert unique_instructions[0].operation.annotations == [InjectNoise("ref")]
+    assert unique_instructions[1].operation.annotations == []
+
+    unique_instructions = find_unique_box_instructions(
+        instructions,
+        normalize_annotations=lambda annotations: [
+            InjectNoise(annot.ref, annot.modifier_ref)
+            for annot in annotations
+            if isinstance(annot, InjectNoise)
+        ],
+    )
+    assert len(unique_instructions) == 3
+    assert unique_instructions[0].operation.annotations == [InjectNoise("ref", "mod_ref")]
+    assert unique_instructions[1].operation.annotations == [
+        InjectNoise("ref", "another_modifier_ref")
+    ]
+    assert unique_instructions[2].operation.annotations == []
+
+
+def test_continue():
+    """
+    Test that ``find_unique_box_instructions`` continues if it finds anything other than a box.
+    """
+    assert find_unique_box_instructions([CXGate()]) == []

--- a/test/unit/test_utils/test_undress_box.py
+++ b/test/unit/test_utils/test_undress_box.py
@@ -12,10 +12,9 @@
 
 """Tests for `undress_box`"""
 
-import pytest
 from qiskit.circuit import BoxOp, ClassicalRegister, Parameter, QuantumCircuit, QuantumRegister
 
-from samplomatic.annotations import BasisTransform, Twirl
+from samplomatic.annotations import Twirl
 from samplomatic.utils import undress_box
 
 
@@ -25,10 +24,10 @@ def test_empty_box():
     assert undress_box(box) == box
 
     box = BoxOp(QuantumCircuit(2), annotations=[Twirl(dressing="left")])
-    assert undress_box(box, Twirl) == box
+    assert undress_box(box) == box
 
     box = BoxOp(QuantumCircuit(2), annotations=[Twirl(dressing="right")])
-    assert undress_box(box, Twirl) == box
+    assert undress_box(box) == box
 
 
 def test_undressed_box():
@@ -61,7 +60,7 @@ def test_left_dressed_box():
     body_expected.rz(ph, 1)
     box_expected = BoxOp(body_expected, annotations=[Twirl(dressing="left")])
 
-    assert undress_box(box, Twirl) == box_expected
+    assert undress_box(box) == box_expected
 
 
 def test_right_dressed_box():
@@ -82,25 +81,4 @@ def test_right_dressed_box():
     body_expected.cx(0, 1)
     box_expected = BoxOp(body_expected, annotations=[Twirl(dressing="right")])
 
-    assert undress_box(box, Twirl) == box_expected
-
-
-@pytest.mark.parametrize(
-    "annotations",
-    [
-        [],
-        [Twirl(dressing="right")],
-        [Twirl(decomposition="rzrx"), BasisTransform(ref="ref")],
-    ],
-)
-def test_annotations_are_removed(annotations):
-    """
-    Test that `undress_box` keeps or removes the annotations depending on ``keep_annotations``.
-    """
-    body = QuantumCircuit(3)
-
-    assert (
-        undress_box(BoxOp(body, annotations=annotations), (Twirl, BasisTransform)).annotations
-        == annotations
-    )
-    assert undress_box(BoxOp(body, annotations=annotations)).annotations == []
+    assert undress_box(box) == box_expected


### PR DESCRIPTION
This PR adds the `find_unique_box_instructions` function, which iterates through the an iterable of ``instructions``, identifies those that contain a `BoxOp` operation and compares them based on the boxes' contents and annotations. It returns a list of instructions that contains unique boxes.