### PR TITLE
Add `Node.NODE_REGISTRY` to keep track of all non-abstract nodes

### DIFF
--- a/samplomatic/samplex/nodes/node.py
+++ b/samplomatic/samplex/nodes/node.py
@@ -12,6 +12,8 @@
 
 """Node"""
 
+import abc
+import inspect
 from numbers import Number
 from typing import Literal
 
@@ -21,8 +23,24 @@ from ...exceptions import SamplexConstructionError
 from ...visualization.hover_style import NodeStyle
 
 
-class Node:
+class NodeType(abc.ABCMeta):
+    """Metaclass used for registering all non-abstract subclasses.
+
+    This is done so that we can automate testing coverage of Node serialization: there is a test
+    that demands each node type does a round-trip.
+    """
+
+    def __new__(mcls, name, bases, namespace):
+        cls = super().__new__(mcls, name, bases, namespace)
+        if cls.__name__ != "Node" and not inspect.isabstract(cls):
+            cls.NODE_REGISTRY.add(cls)
+        return cls
+
+
+class Node(metaclass=NodeType):
     """Parent class for samplex node operations."""
+
+    NODE_REGISTRY: set[type["Node"]] = set()
 
     def __repr__(self):
         register_names = sorted(f"{register_name}(r)" for register_name in self.reads_from())

--- a/test/unit/test_samplex/test_nodes/test_node.py
+++ b/test/unit/test_samplex/test_nodes/test_node.py
@@ -14,6 +14,7 @@ import pytest
 
 from samplomatic.annotations import VirtualType
 from samplomatic.exceptions import SamplexConstructionError
+from samplomatic.samplex.nodes import CollectionNode, EvaluationNode, Node, SamplingNode
 
 from .dummy_nodes import DummyNode
 
@@ -132,3 +133,16 @@ def test_validate_redefines():
     )
 
     assert register_descriptions == {"a": (10, VirtualType.U2)}
+
+
+def test_dummy_is_registered():
+    """Test that the dummy node is in the node registry."""
+    assert DummyNode in Node.NODE_REGISTRY
+
+
+def test_no_abstract_registrations():
+    """Test that the registry mechanism doesn't contain any abstract parents."""
+    assert Node not in Node.NODE_REGISTRY
+    assert SamplingNode not in Node.NODE_REGISTRY
+    assert EvaluationNode not in Node.NODE_REGISTRY
+    assert CollectionNode not in Node.NODE_REGISTRY


### PR DESCRIPTION
## Summary

We want the ability to keep track of all non-abstract nodes so that we can ensure serialization support and correctness for all node types. With this registry, we will be able to ensure round-trip correctness of all node types, and if someone adds a node in the future and forgets to make it serializable, a test will fail.