### PR TITLE
Add metadata specification

### DIFF
--- a/samplomatic/samplex/__init__.py
+++ b/samplomatic/samplex/__init__.py
@@ -12,6 +12,6 @@
 
 """Samplex"""
 
-from .interfaces import MetadataOutput, SamplexInput, SamplexOutput, TensorSpecification
+from .interfaces import MetadataSpecification, SamplexInput, SamplexOutput, TensorSpecification
 from .parameter_expression_table import ParameterExpressionTable
 from .samplex import Samplex

--- a/samplomatic/samplex/nodes/basis_transform_node.py
+++ b/samplomatic/samplex/nodes/basis_transform_node.py
@@ -141,7 +141,7 @@ class BasisTransformNode(SamplingNode):
     def instantiates(self):
         return {self._register_name: (self._num_subsystems, self._basis_change.action.TYPE)}
 
-    def sample(self, registers, rng, inputs, **kwargs):
+    def sample(self, registers, rng, inputs):
         basis = inputs[self._basis_ref]
         registers[self._register_name] = self._basis_change.get_transform(basis)
 

--- a/samplomatic/samplex/nodes/inject_noise_node.py
+++ b/samplomatic/samplex/nodes/inject_noise_node.py
@@ -89,7 +89,7 @@ class InjectNoiseNode(SamplingNode):
         }
 
     def sample(self, registers, rng, inputs, **kwargs):
-        if (noise_map := kwargs.get("noise_maps", {}).get(self._noise_ref)) is None:
+        if (noise_map := inputs.metadata["noise_maps"].get(self._noise_ref)) is None:
             raise SamplexRuntimeError(f"A noise map for '{self._noise_ref}' was not specified.")
         if (num_qubits := noise_map.num_qubits) != self._num_subsystems:
             raise SamplexRuntimeError(
@@ -97,8 +97,8 @@ class InjectNoiseNode(SamplingNode):
                 f"'{self._noise_ref}' when it requires `{self._num_subsystems}`."
             )
         if self._modifier_ref:
-            scale = kwargs.get("noise_scales", {}).get(self._modifier_ref, 1.0)
-            local_scale = kwargs.get("local_scales", {}).get(
+            scale = inputs.metadata["noise_scales"].get(self._modifier_ref, 1.0)
+            local_scale = inputs.metadata["local_scales"].get(
                 self._modifier_ref, np.ones(noise_map.num_terms)
             )
 

--- a/samplomatic/samplex/nodes/sampling_node.py
+++ b/samplomatic/samplex/nodes/sampling_node.py
@@ -27,11 +27,7 @@ class SamplingNode(abc.ABC, Node):
 
     @abc.abstractmethod
     def sample(
-        self,
-        registers: dict[RegisterName, VirtualRegister],
-        rng: Generator,
-        inputs: SamplexInput,
-        **kwargs,
+        self, registers: dict[RegisterName, VirtualRegister], rng: Generator, inputs: SamplexInput
     ):
         """Sample this node.
 

--- a/samplomatic/samplex/nodes/twirl_sampling_node.py
+++ b/samplomatic/samplex/nodes/twirl_sampling_node.py
@@ -75,7 +75,7 @@ class TwirlSamplingNode(SamplingNode):
             self._rhs_register_name: distribution_info,
         }
 
-    def sample(self, registers, rng, inputs, **_):
+    def sample(self, registers, rng, inputs):
         samples = self._distribution.sample(inputs.num_samples, rng)
         registers[self._lhs_register_name] = samples
         registers[self._rhs_register_name] = samples.invert()

--- a/test/integration/test_measurement_twirling.py
+++ b/test/integration/test_measurement_twirling.py
@@ -38,7 +38,7 @@ class TestWithoutSimulation:
         samplex = samplex_state.finalize()
         samplex.finalize()
 
-        samplex_output = samplex.sample([], size=20)
+        samplex_output = samplex.sample(size=20)
         measurement_flips = samplex_output["measurement_flips"]
         assert not np.any(measurement_flips[:, 1:3])
 

--- a/test/integration/test_static_twirling_samples.py
+++ b/test/integration/test_static_twirling_samples.py
@@ -254,7 +254,7 @@ def test_sampling(circuit, save_plot):
     save_plot(lambda: samplex.draw(), "Samplex", delayed=True)
 
     circuit_params = np.random.random(len(circuit.parameters)).tolist()
-    samplex_output = samplex.sample(circuit_params, size=10)
+    samplex_output = samplex.sample(parameter_values=circuit_params, size=10)
     parameter_values = samplex_output["parameter_values"]
 
     expected_op = Operator(remove_boxes(circuit).assign_parameters(circuit_params))

--- a/test/unit/test_samplex/test_interfaces.py
+++ b/test/unit/test_samplex/test_interfaces.py
@@ -14,7 +14,12 @@ import numpy as np
 import pytest
 
 from samplomatic.exceptions import SamplexInputError
-from samplomatic.samplex import MetadataOutput, SamplexInput, SamplexOutput, TensorSpecification
+from samplomatic.samplex import (
+    MetadataSpecification,
+    SamplexInput,
+    SamplexOutput,
+    TensorSpecification,
+)
 
 
 class TestSamplexInput:
@@ -22,11 +27,12 @@ class TestSamplexInput:
 
     def test_empty(self):
         """Test an empty output."""
-        output = SamplexInput([], 5)
-        assert len(output) == 0
-        assert not list(output)
+        input = SamplexInput([], [], 5)
+        assert len(input) == 0
+        assert not list(input)
+        assert input.metadata == {}
 
-        output.validate_and_update()
+        input.validate_and_update()
 
     def test_construction(self):
         """Test construction and simple attributes."""
@@ -36,12 +42,14 @@ class TestSamplexInput:
                 TensorSpecification("a", (5,), np.uint8, "desc_a"),
                 TensorSpecification("b", (3, 7), np.float32, "desc_b"),
             ],
+            [],
             5,
         )
 
         assert len(input) == 2
         assert list(input) == ["a", "b"]
         assert "a" in input and "b" in input
+        assert input.metadata == {}
 
         assert input["a"] is None
         assert input["b"] is None
@@ -59,6 +67,7 @@ class TestSamplexInput:
                 TensorSpecification("a", (5,), np.uint8, "desc_a"),
                 TensorSpecification("b", (3, 7), np.float32, "desc_b"),
             ],
+            [MetadataSpecification("c")],
             5,
         )
         b = np.zeros((3, 7), np.float32)
@@ -71,6 +80,9 @@ class TestSamplexInput:
 
         with pytest.raises(SamplexInputError, match="expects an array"):
             input.validate_and_update(a=np.zeros((7,), np.uint8), b=b)
+
+        with pytest.raises(SamplexInputError, match="metadata input"):
+            input.validate_and_update(a=np.zeros((5,), np.uint8), b=b)
 
 
 class TestSamplexOutput:
@@ -90,7 +102,7 @@ class TestSamplexOutput:
                 TensorSpecification("a", (5,), np.uint8, "desc_a"),
                 TensorSpecification("c", (3, 7), np.float32, "desc_c"),
             ],
-            [MetadataOutput("b", "desc_b")],
+            [MetadataSpecification("b", "desc_b")],
             15,
         )
 

--- a/test/unit/test_samplex/test_nodes/dummy_nodes.py
+++ b/test/unit/test_samplex/test_nodes/dummy_nodes.py
@@ -103,7 +103,7 @@ class DummyCollectionNode(CollectionNode, DummyNode):
 class DummySamplingNode(SamplingNode, DummyNode):
     """Dummy child sampling node for testing."""
 
-    def sample(self, registers, rng, inputs, **_):
+    def sample(self, registers, rng, inputs):
         self._update(registers, rng, inputs.num_samples)
 
 

--- a/test/unit/test_samplex/test_nodes/test_basis_transform_node.py
+++ b/test/unit/test_samplex/test_nodes/test_basis_transform_node.py
@@ -62,7 +62,7 @@ class TestBasisTransformNode:
     def test_sample(self):
         """Test evaluation of the node."""
         basis_change = BasisTransformNode("basis_change", MEAS_PAULI_BASIS, "measure", 3)
-        samplex_input = SamplexInput([TensorSpecification("measure", (3,), np.uint8)], None)
+        samplex_input = SamplexInput([TensorSpecification("measure", (3,), np.uint8)], [], None)
         registers = {}
 
         samplex_input.validate_and_update(measure=np.array([1, 1, 2], dtype=np.uint8))

--- a/test/unit/test_samplex/test_nodes/test_twirl_sampling_node.py
+++ b/test/unit/test_samplex/test_nodes/test_twirl_sampling_node.py
@@ -32,5 +32,5 @@ def test_sample(rng):
     registers = {}
     node = TwirlSamplingNode("lhs", "rhs", UniformPauli(10))
 
-    node.sample(registers, rng, SamplexInput([], 5))
+    node.sample(registers, rng, SamplexInput([], [], 5))
     assert registers["lhs"].multiply(registers["rhs"]) == PauliRegister.identity(10, 5)

--- a/test/unit/test_samplex/test_samplex.py
+++ b/test/unit/test_samplex/test_samplex.py
@@ -18,14 +18,14 @@ from qiskit.circuit import Parameter
 
 from samplomatic.exceptions import SamplexConstructionError, SamplexRuntimeError
 from samplomatic.optionals import HAS_PLOTLY
-from samplomatic.samplex import MetadataOutput, Samplex, TensorSpecification
+from samplomatic.samplex import MetadataSpecification, Samplex, TensorSpecification
 from samplomatic.virtual_registers import PauliRegister, U2Register
 
 from .test_nodes.dummy_nodes import DummyCollectionNode, DummyEvaluationNode, DummySamplingNode
 
 
 class DummySamplingErrorNode(DummySamplingNode):
-    def sample(self, registers, rng, inputs, **kwargs):
+    def sample(self, registers, rng, inputs):
         raise SamplexRuntimeError("This node cannot sample.")
 
 
@@ -68,9 +68,9 @@ class TestBasic:
     def test_add_output_fails(self):
         """Test that adding an output fails when it should."""
         samplex = Samplex()
-        samplex.add_output(MetadataOutput("out"))
+        samplex.add_output(MetadataSpecification("out"))
         with pytest.raises(SamplexConstructionError, match="'out' already exists"):
-            samplex.add_output(MetadataOutput("out"))
+            samplex.add_output(MetadataSpecification("out"))
 
     def test_add_node_fails(self):
         """Test that adding a node fails when expected."""


### PR DESCRIPTION
## Summary

Closes #34.

## Details and comments

This PR replaces `MetadataOutput` with `MetadataSpecification` and uses it for specifying all the metadata inputs on `Samplex.sample`. It also simplifies the signature of `SamplingNode.sample`.