### PR TITLE
Add pre-commit stage to rebuild docs/apidocs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,15 @@ repos:
         pass_filenames: false
         args: [-b, indexes-indices, -b, graphvis-graphviz]
 
+  - repo: local
+    hooks:
+      - id: api-docs
+        name: Rebuild API doctree
+        entry: sphinx-apidoc -o docs/apidocs --force --remove-old --no-toc --module-first ./samplomatic
+        language: system
+        types: [python]
+        pass_filenames: false
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.4
     hooks:

--- a/docs/apidocs/samplomatic.rst
+++ b/docs/apidocs/samplomatic.rst
@@ -66,3 +66,11 @@ samplomatic.partition module
    :members:
    :show-inheritance:
    :undoc-members:
+
+samplomatic.tensor\_interface module
+------------------------------------
+
+.. automodule:: samplomatic.tensor_interface
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/apidocs/samplomatic.samplex.rst
+++ b/docs/apidocs/samplomatic.samplex.rst
@@ -40,3 +40,11 @@ samplomatic.samplex.samplex module
    :members:
    :show-inheritance:
    :undoc-members:
+
+samplomatic.samplex.samplex\_serialization module
+-------------------------------------------------
+
+.. automodule:: samplomatic.samplex.samplex_serialization
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/apidocs/samplomatic.utils.rst
+++ b/docs/apidocs/samplomatic.utils.rst
@@ -33,6 +33,14 @@ samplomatic.utils.get\_annotation module
    :show-inheritance:
    :undoc-members:
 
+samplomatic.utils.serialization module
+--------------------------------------
+
+.. automodule:: samplomatic.utils.serialization
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 samplomatic.utils.undress\_box module
 -------------------------------------
 


### PR DESCRIPTION
## Summary

This PR adds a new pre-commit stage which rebuilds the API doctree. This will help us keep it up to date as we add/move/remove files.

## Details and comments
