### PR TITLE
Add aliases for Parameter and ParameterExpression

### DIFF
--- a/samplomatic/aliases.py
+++ b/samplomatic/aliases.py
@@ -17,7 +17,8 @@ from typing import Literal, Protocol, TypeAlias, TypeVar
 
 import numpy as np
 from qiskit.circuit import CircuitInstruction as _CircuitInstruction
-from qiskit.circuit import Parameter, ParameterExpression
+from qiskit.circuit import Parameter as _Parameter
+from qiskit.circuit import ParameterExpression as _ParameterExpression
 from qiskit.circuit import Qubit as _Qubit
 from rustworkx.rustworkx import PyDiGraph
 
@@ -26,6 +27,8 @@ S = TypeVar("S")
 
 # this alias patches a qiskit/pyo3 typing bug, it can be removed when fixed in qiskit
 CircuitInstruction: TypeAlias = _CircuitInstruction  #  type: ignore
+Parameter: TypeAlias = _Parameter  #  type: ignore
+ParameterExpression: TypeAlias = _ParameterExpression  #  type: ignore
 Qubit: TypeAlias = _Qubit  # type:ignore
 
 EdgeIndex: TypeAlias = int

--- a/samplomatic/builders/param_iter.py
+++ b/samplomatic/builders/param_iter.py
@@ -14,7 +14,7 @@
 
 from typing import Self
 
-from qiskit.circuit import Parameter
+from ..aliases import Parameter
 
 
 class ParamIter:

--- a/samplomatic/builders/specs.py
+++ b/samplomatic/builders/specs.py
@@ -14,9 +14,16 @@ import enum
 from dataclasses import dataclass, field
 
 import numpy as np
-from qiskit.circuit import Parameter
 
-from ..aliases import CircuitInstruction, ClbitIndex, ParamIndices, ParamSpec, Qubit, StrRef
+from ..aliases import (
+    CircuitInstruction,
+    ClbitIndex,
+    Parameter,
+    ParamIndices,
+    ParamSpec,
+    Qubit,
+    StrRef,
+)
 from ..annotations import DressingMode, VirtualType
 from ..partition import QubitPartition
 from ..synths import Synth

--- a/samplomatic/samplex/parameter_expression_table.py
+++ b/samplomatic/samplex/parameter_expression_table.py
@@ -13,9 +13,9 @@
 """ParameterExpressionTable"""
 
 import numpy as np
-from qiskit.circuit import Parameter, ParameterExpression, ParameterVectorElement
+from qiskit.circuit import ParameterVectorElement
 
-from ..aliases import ParamIndex, ParamName, ParamValues
+from ..aliases import Parameter, ParameterExpression, ParamIndex, ParamName, ParamValues
 from ..exceptions import ParameterError
 
 

--- a/samplomatic/samplex/samplex.py
+++ b/samplomatic/samplex/samplex.py
@@ -17,7 +17,6 @@ from concurrent.futures import Future, ThreadPoolExecutor, as_completed, wait
 from typing import TYPE_CHECKING, Self
 
 from numpy.random import Generator, SeedSequence, default_rng
-from qiskit.circuit import Parameter, ParameterExpression
 from rustworkx.rustworkx import PyDiGraph, topological_generations
 
 from ..aliases import (
@@ -27,6 +26,8 @@ from ..aliases import (
     LayoutPresets,
     NodeIndex,
     NumSubsystems,
+    Parameter,
+    ParameterExpression,
     ParamIndex,
     ParamSpec,
     RegisterName,

--- a/samplomatic/samplex/samplex_serialization.py
+++ b/samplomatic/samplex/samplex_serialization.py
@@ -18,13 +18,12 @@ import uuid
 
 import orjson
 import pybase64
-from qiskit.circuit import Parameter, ParameterExpression
 
 # This is super private in Qiskit and on every upgrade should be checked for changes
 from qiskit.qpy.binary_io.value import _read_parameter_expr_v13, _write_parameter_expression_v13
 from rustworkx import PyDiGraph, node_link_json, parse_node_link_json
 
-from ..aliases import InterfaceName
+from ..aliases import InterfaceName, Parameter, ParameterExpression
 from ..exceptions import DeserializationError
 from ..tensor_interface import Specification, TensorSpecification
 from .nodes import Node


### PR DESCRIPTION
## Summary

There's a typing bug in qiskit we've already encountered with `CircuitInstruction`, as of the RC of 2.2.0 it's also present for `Parameter`/`ParameterExpression`.

## Details and comments
