### PR TITLE
Add all annotations to top level module

### DIFF
--- a/docs/apidocs/samplomatic.rst
+++ b/docs/apidocs/samplomatic.rst
@@ -51,14 +51,6 @@ samplomatic.exceptions module
    :show-inheritance:
    :undoc-members:
 
-samplomatic.noise\_model module
--------------------------------
-
-.. automodule:: samplomatic.noise_model
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
 samplomatic.optionals module
 ----------------------------
 

--- a/docs/apidocs/samplomatic.samplex.rst
+++ b/docs/apidocs/samplomatic.samplex.rst
@@ -25,14 +25,6 @@ samplomatic.samplex.interfaces module
    :show-inheritance:
    :undoc-members:
 
-samplomatic.samplex.noise\_model\_requirement module
-----------------------------------------------------
-
-.. automodule:: samplomatic.samplex.noise_model_requirement
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
 samplomatic.samplex.parameter\_expression\_table module
 -------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The goal is to put the main interface of the package into the top-level module.

## Details and comments
