### PR TITLE
Simplify shot axis handling in `CollectZ2Node`

### DIFF
--- a/samplomatic/pre_samplex/pre_samplex.py
+++ b/samplomatic/pre_samplex/pre_samplex.py
@@ -1522,7 +1522,6 @@ class PreSamplex:
                 np.array(pre_node.subsystems_idxs[reg_name]),
                 f"measurement_flips.{reg_name}",
                 clbit_idxs,
-                1,
             )
 
             samplex.add_edge(combine_node_idx, samplex.add_node(z2collect))

--- a/samplomatic/samplex/nodes/collect_z2_to_output_node.py
+++ b/samplomatic/samplex/nodes/collect_z2_to_output_node.py
@@ -31,8 +31,6 @@ class CollectZ2ToOutputNode(CollectionNode):
         subsystem_idxs: The subsystems to read from.
         output_name: The name of the output to write to.
         output_idxs: The indices of the output to write to.
-        num_dummy_axes: Number of dummy axes (length 1) in the output array between the
-            randomizations axis and the the ``output_idxs`` axis. Defaults to 0.
     """
 
     def __init__(
@@ -41,15 +39,11 @@ class CollectZ2ToOutputNode(CollectionNode):
         subsystem_idxs: Sequence[SubsystemIndex],
         output_name: InterfaceName,
         output_idxs: Sequence[OutputIndex],
-        num_dummy_axes: int = 0,
     ):
         self._register_name = register_name
         self._output_name = output_name
         self._subsystem_idxs = np.asarray(subsystem_idxs, dtype=np.uint32)
-        self._output_idxs = (
-            (slice(None),) + (0,) * num_dummy_axes + (np.asarray(output_idxs, dtype=np.uint32),)
-        )
-        self._num_dummy_axes = num_dummy_axes
+        self._output_idxs = np.asarray(output_idxs, dtype=np.uint32)
 
     def _to_json_dict(self) -> dict[str, str]:
         return {
@@ -57,8 +51,7 @@ class CollectZ2ToOutputNode(CollectionNode):
             "register_name": self._register_name,
             "output_name": self._output_name,
             "subsystem_indices": array_to_json(self._subsystem_idxs),
-            "output_indices": array_to_json(self._output_idxs[-1]),
-            "num_dummy_axes": str(self._num_dummy_axes),
+            "output_indices": array_to_json(self._output_idxs),
         }
 
     @classmethod
@@ -68,14 +61,13 @@ class CollectZ2ToOutputNode(CollectionNode):
             array_from_json(data["subsystem_indices"]),
             data["output_name"],
             array_from_json(data["output_indices"]),
-            int(data["num_dummy_axes"]),
         )
 
     def reads_from(self):
         return {self._register_name: (set(self._subsystem_idxs), VirtualType.Z2)}
 
     def outputs_to(self):
-        return {self._output_name: (set(self._output_idxs[-1]), VirtualType.Z2)}
+        return {self._output_name: (set(self._output_idxs), VirtualType.Z2)}
 
     def validate_and_update(self, register_descriptions):
         super().validate_and_update(register_descriptions)
@@ -89,7 +81,8 @@ class CollectZ2ToOutputNode(CollectionNode):
 
     def collect(self, registers, outputs, rng):
         register = registers[self._register_name]
-        outputs[self._output_name][self._output_idxs] = register.virtual_gates[
+        output = outputs[self._output_name]
+        output.reshape(-1, output.shape[-1])[:, self._output_idxs] = register.virtual_gates[
             self._subsystem_idxs, :
         ].transpose(1, 0)
 

--- a/test/unit/test_samplex/test_nodes/test_collect_z2_to_output_node.py
+++ b/test/unit/test_samplex/test_nodes/test_collect_z2_to_output_node.py
@@ -75,8 +75,8 @@ def test_collect_with_dummy_axes(rng):
     reg1 = Z2Register([[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 1], [0, 1, 1]])
     reg2 = Z2Register([[0, 0, 0], [1, 1, 1], [1, 1, 1], [1, 0, 1], [1, 1, 0]])
 
-    node1 = CollectZ2ToOutputNode("reg1", [0, 1, 2, 3, 4], "out", [0, 2, 4, 6, 8], 1)
-    node2 = CollectZ2ToOutputNode("reg2", [4, 3, 2, 1, 0], "out", [1, 3, 5, 7, 9], 1)
+    node1 = CollectZ2ToOutputNode("reg1", [0, 1, 2, 3, 4], "out", [0, 2, 4, 6, 8])
+    node2 = CollectZ2ToOutputNode("reg2", [4, 3, 2, 1, 0], "out", [1, 3, 5, 7, 9])
 
     outputs = SamplexOutput(
         [


### PR DESCRIPTION
## Summary

We assume that the output will have shape `(num_randomizations, 1, ..., 1, num_qubits)` so we use a slice of the form `(slice(None), 0, ..., 0, [clbit_idxs])` in the current approach. Rather than storing an additional attribute (the number of dummy axes) and mutating slices, we can get a reshaped view of the output array as `(num_randomizations, num_qubits)` and slice with `(slice(None), [clbit_idxs])`/`[:, clbit_idxs]`.

## Details and comments
