### PR TITLE
Add alias for DAGOpNode

### DIFF
--- a/samplomatic/aliases.py
+++ b/samplomatic/aliases.py
@@ -31,6 +31,7 @@ from qiskit.circuit import CircuitInstruction as _CircuitInstruction
 from qiskit.circuit import Parameter as _Parameter
 from qiskit.circuit import ParameterExpression as _ParameterExpression
 from qiskit.circuit import Qubit as _Qubit
+from qiskit.dagcircuit import DAGOpNode as _DAGOpNode
 from rustworkx.rustworkx import PyDiGraph
 
 T = TypeVar("T")
@@ -38,6 +39,7 @@ S = TypeVar("S")
 
 # this alias patches a qiskit/pyo3 typing bug, it can be removed when fixed in qiskit
 CircuitInstruction: TypeAlias = _CircuitInstruction  #  type: ignore
+DAGOpNode: TypeAlias = _DAGOpNode  # type: ignore
 Parameter: TypeAlias = _Parameter  #  type: ignore
 ParameterExpression: TypeAlias = _ParameterExpression  #  type: ignore
 Qubit: TypeAlias = _Qubit  # type:ignore

--- a/samplomatic/transpiler/passes/group_gates_into_boxes.py
+++ b/samplomatic/transpiler/passes/group_gates_into_boxes.py
@@ -17,10 +17,11 @@ from __future__ import annotations
 from collections import defaultdict
 
 from qiskit.circuit import Bit, Qubit
-from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 
+from ...aliases import DAGOpNode
 from .utils import make_and_insert_box, validate_op_is_supported
 
 

--- a/samplomatic/transpiler/passes/group_meas_into_boxes.py
+++ b/samplomatic/transpiler/passes/group_meas_into_boxes.py
@@ -19,10 +19,11 @@ from collections import defaultdict
 from typing import Literal
 
 from qiskit.circuit import Annotation, Bit, Qubit
-from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 
+from ...aliases import DAGOpNode
 from ...annotations import BasisTransform, Twirl
 from .utils import make_and_insert_box, validate_op_is_supported
 

--- a/samplomatic/transpiler/passes/inline_boxes.py
+++ b/samplomatic/transpiler/passes/inline_boxes.py
@@ -14,8 +14,10 @@
 
 from qiskit.circuit import Clbit, Qubit
 from qiskit.converters import circuit_to_dag
-from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
+
+from ...aliases import DAGOpNode
 
 
 class InlineBoxes(TransformationPass):

--- a/samplomatic/transpiler/passes/utils.py
+++ b/samplomatic/transpiler/passes/utils.py
@@ -17,9 +17,10 @@ from __future__ import annotations
 from collections.abc import Iterator
 
 from qiskit.circuit import Annotation, BoxOp, QuantumCircuit
-from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.exceptions import TranspilerError
 
+from ...aliases import DAGOpNode
 from ...annotations import Twirl
 
 

--- a/samplomatic/utils/box_key.py
+++ b/samplomatic/utils/box_key.py
@@ -16,9 +16,8 @@ from collections.abc import Hashable
 
 from qiskit.circuit import Clbit, Qubit
 from qiskit.converters import circuit_to_dag
-from qiskit.dagcircuit import DAGOpNode
 
-from ..aliases import CircuitInstruction
+from ..aliases import CircuitInstruction, DAGOpNode
 from ..constants import SYMMETRIC_2Q_GATES
 
 


### PR DESCRIPTION
## Summary

Classes exposed with PyO3 have issues with type checking and we get around this by adding aliases. This PR adds one for DAGOpNode.

## Details and comments
