### PR TITLE
Add ruff D3XX (pydocstyle) ruleset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ vis = [
 [tool.ruff]
 lint.select = [
     "D100", "D401",     # pydocstyle
-    "D2",               # pydocstyle
+    "D2", "D3",         # pydocstyle
     "E",      # pycodestyle
     "F",      # pyflake
     "I",      # isort

--- a/samplomatic/samplex/nodes/collect_z2_to_output_node.py
+++ b/samplomatic/samplex/nodes/collect_z2_to_output_node.py
@@ -24,7 +24,7 @@ from .collection_node import CollectionNode
 
 
 class CollectZ2ToOutputNode(CollectionNode):
-    """Reads from :class:`~.Z2Register`\\s and writes to :class:`~.SamplexOutput`.
+    r"""Reads from :class:`~.Z2Register`\s and writes to :class:`~.SamplexOutput`.
 
     Args:
         register_name: The name of the register to read from.

--- a/samplomatic/samplex/parameter_expression_table.py
+++ b/samplomatic/samplex/parameter_expression_table.py
@@ -26,10 +26,10 @@ def _sort_key(parameter: Parameter):
 
 
 class ParameterExpressionTable:
-    """Evaluates a list of parameter expressions given a list of parameter values.
+    r"""Evaluates a list of parameter expressions given a list of parameter values.
 
-    An instance of this class owns an ordered list of :math:`M` :class:`ParameterExpression`\\s
-    that together implicitly specify an ordered list of distinct :math:`N` :class:`Parameter`\\s.
+    An instance of this class owns an ordered list of :math:`M` :class:`ParameterExpression`\s
+    that together implicitly specify an ordered list of distinct :math:`N` :class:`Parameter`\s.
     Because parameter expressions can involve multiple parameters, because distinct parameter
     expressions can reference the same parameters, and because parameter expressions that are
     completely bound contain no parameters, there is in general no relationship between
@@ -49,7 +49,7 @@ class ParameterExpressionTable:
         self._sorted = True
 
     def append(self, expression: ParameterExpression) -> ParamIndex:
-        """Add a parameter expression to the table.
+        r"""Add a parameter expression to the table.
 
         Args:
             expression: The parameter expression to append.
@@ -60,7 +60,7 @@ class ParameterExpressionTable:
         Raises:
             ParameterError: If the expression contains a parameter that is not already in this table
                 but whose name conflicts with an existing parameter. Keep in mind that
-                :class:`Parameter`\\s use instance equality.
+                :class:`Parameter`\s use instance equality.
         """
         for parameter in expression.parameters:
             if self._parameters.get(name := parameter.name) not in (None, parameter):
@@ -97,11 +97,11 @@ class ParameterExpressionTable:
         return len(self._expressions)
 
     def evaluate(self, parameter_values: ParamValues) -> np.ndarray:
-        """Return one numeric value for each expression.
+        r"""Return one numeric value for each expression.
 
         Args:
             parameter_values: The parameter values, either as a map from parameters to their values,
-                or just the values in parameter-sorted order (see :attr:`~parameters`\\).
+                or just the values in parameter-sorted order (see :attr:`~parameters`\).
 
         Returns:
             An array of evaluated expressions.

--- a/samplomatic/virtual_registers/pauli_register.py
+++ b/samplomatic/virtual_registers/pauli_register.py
@@ -35,14 +35,14 @@ respectively.
 
 
 class PauliRegister(GroupRegister):
-    """Virtual register of virtual projective Pauli gates.
+    r"""Virtual register of virtual projective Pauli gates.
 
     Here, projective means we are modding out the centralizer, in other words, ignoring phases.
 
     The Paulis I, X, Y, and Z correspond to 0, 2, 3, and 1 respectively.
     The non-alphabetical assignment of Y and Z is because it is more convenient
     in most calculations to have them in symplectic ordering. I.e., for a projective
-    Pauli operation :math:`P = X^x Z^z` with :math:`x,z\\in\\mathbb{Z}_2`, we
+    Pauli operation :math:`P = X^x Z^z` with :math:`x,z\in\mathbb{Z}_2`, we
     order according to binary number `zx`.
     """
 

--- a/samplomatic/virtual_registers/virtual_register.py
+++ b/samplomatic/virtual_registers/virtual_register.py
@@ -100,10 +100,10 @@ class VirtualRegister(metaclass=VirtualRegisterMeta):
 
     @staticmethod
     def select(register_type: VirtualType) -> type["VirtualRegister"]:
-        """Select a :class:`~.VirtualRegister` subclass based on a :class:`~.VirtualType` enum.
+        r"""Select a :class:`~.VirtualRegister` subclass based on a :class:`~.VirtualType` enum.
 
         ..note::
-            Not all :class:`~.VirtualRegister`\\s need to define a :attr:`TYPE`, though they will
+            Not all :class:`~.VirtualRegister`\s need to define a :attr:`TYPE`, though they will
             need to if they want to participate in many types of :class:`~.Node` actions.
             Conversely, not every :class:`~.VirtualType` must correspond to a
             :class:`~.VirtualRegister`, most notably intermediate abstractions like


### PR DESCRIPTION
## Summary

This ruleset only has two members, D301 and D302, which are both about quote formatting.
https://docs.astral.sh/ruff/rules/#pydocstyle-d

## Details and comments
