### PR TITLE
Add links to source in API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,7 +182,7 @@ def linkcode_resolve(domain, info):
         linespec = f"#L{lineno}-L{ending_lineno}"
     return (
         "https://github.com/Qiskit/samplomatic/tree/"
-        f"{determine_github_branch()}/{file_name}{linespec}"
+        f"{determine_github_branch()}/samplomatic/{file_name}{linespec}"
     )
 
 


### PR DESCRIPTION
## Summary
The `[SOURCE]` link is new via this PR

<img width="857" height="163" alt="image" src="https://github.com/user-attachments/assets/8c8b43c7-7595-4b93-9bed-f8d4f028e174" />


## Details and comments
