### PR TITLE
Correct argument name: enable_measures -> enable_measure

### DIFF
--- a/docs/guides/transpiler.ipynb
+++ b/docs/guides/transpiler.ipynb
@@ -55,7 +55,7 @@
     "## Group operations into boxes\n",
     "\n",
     "The argument ``enable_gates`` can be set to ``True`` or ``False`` to specify whether the two-qubit gates should be grouped into\n",
-    "boxes. Similarly, ``enable_measures`` allows specifying whether or not measurements should be grouped. The following\n",
+    "boxes. Similarly, ``enable_measure`` allows specifying whether or not measurements should be grouped. The following\n",
     "snippet shows an example where both gates and measurements are grouped."
    ]
   },
@@ -70,7 +70,7 @@
     "\n",
     "boxing_pass_manager = generate_boxing_pass_manager(\n",
     "    enable_gates=True,\n",
-    "    enable_measures=True,\n",
+    "    enable_measure=True,\n",
     ")\n",
     "transpiled_circuit = boxing_pass_manager.run(circuit)\n",
     "transpiled_circuit.draw(\"mpl\", scale=0.8)"
@@ -100,7 +100,7 @@
    "source": [
     "boxing_pass_manager = generate_boxing_pass_manager(\n",
     "    enable_gates=False,\n",
-    "    enable_measures=True,\n",
+    "    enable_measure=True,\n",
     ")\n",
     "transpiled_circuit = boxing_pass_manager.run(circuit)\n",
     "transpiled_circuit.draw(\"mpl\", scale=0.8)"
@@ -115,7 +115,7 @@
     "\n",
     "All the two-qubit gates and measurement boxes in the returned circuit own left-dressed annotations. In particular,\n",
     "all the boxes that contain two-qubit gates are annotated with a {class}`.~Twirl`, while for measurement boxes, users can\n",
-    "choose between {class}`.~Twirl`, {class}`.~BasisTranform` (with ``mode`` aset to ``\"measure\"``), or both. The following code\n",
+    "choose between {class}`.~Twirl`, {class}`.~BasisTranform` (with ``mode`` set to ``\"measure\"``), or both. The following code\n",
     "generates a circuit where the all the boxes are twirled, and the measurement boxes are additionally annotated with\n",
     "{class}`.~BasisTranform`."
    ]
@@ -129,7 +129,7 @@
    "source": [
     "boxing_pass_manager = generate_boxing_pass_manager(\n",
     "    enable_gates=True,\n",
-    "    enable_measures=True,\n",
+    "    enable_measure=True,\n",
     "    measure_annotations=\"all\",\n",
     ")\n",
     "transpiled_circuit = boxing_pass_manager.run(circuit)"
@@ -156,7 +156,7 @@
    "source": [
     "boxing_pass_manager = generate_boxing_pass_manager(\n",
     "    enable_gates=True,\n",
-    "    enable_measures=True,\n",
+    "    enable_measure=True,\n",
     "    inject_noise_targets=\"gates\",\n",
     ")\n",
     "transpiled_circuit = boxing_pass_manager.run(circuit)"
@@ -191,7 +191,7 @@
    "source": [
     "boxing_pass_manager = generate_boxing_pass_manager(\n",
     "    enable_gates=True,\n",
-    "    enable_measures=True,\n",
+    "    enable_measure=True,\n",
     "    inject_noise_targets=\"gates\",\n",
     "    inject_noise_strategy=\"individual_modification\",\n",
     ")\n",
@@ -325,7 +325,7 @@
     "\n",
     "boxing_pass_manager = generate_boxing_pass_manager(\n",
     "    enable_gates=True,\n",
-    "    enable_measures=True,\n",
+    "    enable_measure=True,\n",
     ")\n",
     "transpiled_circuit = boxing_pass_manager.run(circuit)\n",
     "\n",
@@ -383,7 +383,7 @@
    "source": [
     "boxing_pass_manager = generate_boxing_pass_manager(\n",
     "    enable_gates=True,\n",
-    "    enable_measures=True,\n",
+    "    enable_measure=True,\n",
     ")\n",
     "transpiled_circuit = boxing_pass_manager.run(circuit_with_unmeasured_qubit)\n",
     "transpiled_circuit.draw(\"mpl\", scale=0.8)"
@@ -407,7 +407,7 @@
    "source": [
     "boxing_pass_manager = generate_boxing_pass_manager(\n",
     "    enable_gates=True,\n",
-    "    enable_measures=False,\n",
+    "    enable_measure=False,\n",
     ")\n",
     "transpiled_circuit = boxing_pass_manager.run(circuit_with_unmeasured_qubit)\n",
     "transpiled_circuit.draw(\"mpl\", scale=0.8)"


### PR DESCRIPTION
This commit corrects a couple of errors in [docs/guides/transpiler.ipynb](https://github.com/Qiskit/samplomatic/compare/methodname-typo?expand=1#diff-bdbacdf0391aa14d9a2b432d13029d526ccfd8c17ae7d80f2defe634c5095853)

* Maybe this is a typo or the name of the argument has been changed.
* Correct typo "aset" -> "set"
