### PR TITLE
Remove obsolete lines from Samplex.inputs docstring

### DIFF
--- a/samplomatic/samplex/samplex.py
+++ b/samplomatic/samplex/samplex.py
@@ -299,10 +299,6 @@ class Samplex:
     def inputs(self) -> TensorInterface:
         """Return an object that specifies and helps build the required inputs of :meth:`~sample`.
 
-        Raises:
-            ValueError: If the samplex has :meth:`~noise_requirements` and the noise oracle
-                has not been set.
-
         Returns:
             The input interface for this samplex.
         """


### PR DESCRIPTION
The docstring referred to a `ValueError` being raised. But the corresponding code no longer exists.

This commit removes the obsolete lines.

