### PR TITLE
Fix doc release config, again

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,8 +71,8 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/download-artifact@v4
       - name: Download artifact
-        uses: actions/download-artifact@v4
         with:
           name: sphinx-docs
           path: site


### PR DESCRIPTION
## Summary

It's failing because it can't find a git folder, because we put the uses at the wrong indentation, I expect.

## Details and comments
