### PR TITLE
Add clarification to description of `pauli_signs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   boolean values. In particular, values written by this node now represent the parity of the number of
   non-trivial factors in the sampled error that arise from negative rates. In other words, when using
   the boolean written by this node to implement basic PEC, the sign used to correct expectation values
-  should be `-1**bool_value`. ([#188](https://github.com/Qiskit/samplomatic/issues/188))
+  should be `(-1)**bool_value`. ([#188](https://github.com/Qiskit/samplomatic/issues/188))
 
 ### Fixed
 

--- a/samplomatic/pre_samplex/pre_samplex.py
+++ b/samplomatic/pre_samplex/pre_samplex.py
@@ -1165,8 +1165,10 @@ class PreSamplex:
                     np.dtype(np.bool_),
                     "Signs from sampled Pauli Lindblad maps, where boolean values represent the "
                     "parity of the number of non-trivial factors in the sampled error that arise "
-                    "from negative rates. The order matches the iteration order of boxes in the "
-                    "original circuit with noise injection annotations.",
+                    "from negative rates. In other words, in order to implement basic PEC, the "
+                    "sign used to correct expectation values should be ``(-1)**bool_value``. The "
+                    "order matches the iteration order of boxes in the original circuit with noise "
+                    "injection annotations.",
                 )
             )
 


### PR DESCRIPTION
This PR adds a clarification to description of `pauli_signs`, explaining how to use them for PEC.