### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @Qiskit/qiskit-primitives


### PR DESCRIPTION
## Summary

We'll switch to github permissions for now, the codeowners file is mostly just making noise for folks.

## Details and comments
