### PR TITLE
Clean up constructor overloading/inheritance in transpiler passes

### DIFF
--- a/samplomatic/transpiler/passes/add_inject_noise.py
+++ b/samplomatic/transpiler/passes/add_inject_noise.py
@@ -66,7 +66,7 @@ class AddInjectNoise(TransformationPass):
         prefix_modifier_ref: str = "m",
         targets: Literal["none", "gates", "measures", "all"] = "none",
     ):
-        TransformationPass.__init__(self)
+        super().__init__()
         self.strategy = NoiseInjectionStrategy(strategy)
         self.overwrite = overwrite
         self.prefix_ref = prefix_ref

--- a/samplomatic/transpiler/passes/add_terminal_right_dressed_boxes.py
+++ b/samplomatic/transpiler/passes/add_terminal_right_dressed_boxes.py
@@ -73,9 +73,6 @@ class AddTerminalRightDressedBoxes(TransformationPass):
         into the boxes this pass adds.
     """
 
-    def __init__(self):
-        TransformationPass.__init__(self)
-
     @classmethod
     def _new_box(cls, qubits: Iterable[Qubit], qubit_map: dict[Qubit, int]) -> BoxOp:
         # we go a bit out of our way to use the same qubit instances as the original circuit and

--- a/samplomatic/transpiler/passes/group_gates_into_boxes.py
+++ b/samplomatic/transpiler/passes/group_gates_into_boxes.py
@@ -45,9 +45,6 @@ class GroupGatesIntoBoxes(TransformationPass):
         either use :class`~.AddTerminalRightDressedBoxes` to add right-dressed "collector" boxes.
     """
 
-    def __init__(self):
-        TransformationPass.__init__(self)
-
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         """Collect the operations in the dag inside left-dressed boxes.
 

--- a/samplomatic/transpiler/passes/group_meas_into_boxes.py
+++ b/samplomatic/transpiler/passes/group_meas_into_boxes.py
@@ -57,7 +57,7 @@ class GroupMeasIntoBoxes(TransformationPass):
         annotations: Literal["twirl", "change_basis", "all"] = "twirl",
         prefix_ref: str = "basis",
     ):
-        TransformationPass.__init__(self)
+        super().__init__()
 
         if annotations not in SUPPORTED_ANNOTATIONS:
             raise ValueError(

--- a/samplomatic/transpiler/passes/inline_boxes.py
+++ b/samplomatic/transpiler/passes/inline_boxes.py
@@ -26,9 +26,6 @@ class InlineBoxes(TransformationPass):
     Every annotation that is present in the boxes is ignored.
     """
 
-    def __init__(self):
-        TransformationPass.__init__(self)
-
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         inlined_dag = dag.copy_empty_like()
         for node in dag.op_nodes():

--- a/samplomatic/transpiler/passes/insert_noops/add_noops.py
+++ b/samplomatic/transpiler/passes/insert_noops/add_noops.py
@@ -28,7 +28,8 @@ class AddNoops(TransformationPass):
     """
 
     def __init__(self, qubits: Iterable[int] | Iterable[Qubit]):
-        TransformationPass.__init__(self)
+        super().__init__()
+
         if not (
             all(isinstance(qubit, int) for qubit in qubits)
             or all(isinstance(qubit, Qubit) for qubit in qubits)

--- a/samplomatic/transpiler/passes/insert_noops/add_noops_active_accum.py
+++ b/samplomatic/transpiler/passes/insert_noops/add_noops_active_accum.py
@@ -24,9 +24,6 @@ class AddNoopsActiveAccum(TransformationPass):
     part of a previous box.
     """
 
-    def __init__(self):
-        TransformationPass.__init__(self)
-
     def run(self, dag: DAGCircuit):
         # create a new dag to allow for mid-circuit modifications
         modified_dag: DAGCircuit = dag.copy_empty_like()

--- a/samplomatic/transpiler/passes/insert_noops/add_noops_active_circuit.py
+++ b/samplomatic/transpiler/passes/insert_noops/add_noops_active_circuit.py
@@ -27,9 +27,6 @@ class AddNoopsActiveCircuit(TransformationPass):
     marked as active at any other point in the circuit.
     """
 
-    def __init__(self):
-        TransformationPass.__init__(self)
-
     def run(self, dag: DAGCircuit):
         qubits = set(qubit for box_node in dag.op_nodes(BoxOp) for qubit in box_node.qargs)
         return AddNoops(qubits).run(dag)

--- a/samplomatic/transpiler/passes/insert_noops/add_noops_all.py
+++ b/samplomatic/transpiler/passes/insert_noops/add_noops_all.py
@@ -25,8 +25,5 @@ class AddNoopsAll(TransformationPass):
     defined when initializing the `QuantumCircuit` object.
     """
 
-    def __init__(self):
-        TransformationPass.__init__(self)
-
     def run(self, dag: DAGCircuit):
         return AddNoops(dag.qubits).run(dag)


### PR DESCRIPTION
## Summary

This PR fixes several trivial overloads of transpiler class constructors, and also some unconventional invocations of the parent constructor.

## Details and comments
