### PR TITLE
Add rich circuit comparison to QuantumCircuit comparisons

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -91,7 +91,14 @@ def maybe_clear_assets():
 
 
 def circuit_description(circuit: QuantumCircuit) -> list[str]:
-    """Return a detailed description of a circuit."""
+    """Return a detailed description of a circuit.
+
+    Args:
+        circuit: The circuit to describe.
+
+    Returns:
+        A list of string lines.
+    """
     return [
         repr(circuit),
         f" * num_qubits={circuit.num_qubits} (qubits hash is {hash(tuple(circuit.qubits))})",


### PR DESCRIPTION
## Summary
This PR updates the pytest configuration to display a rich circuit comparison whenever QuantumCircuit equality is asserted.

## Details and comments

You may need to send `-v` or `-vv` to pytest to get it to render enough of the diff to be useful.
