### PR TITLE
Update the transpiler guide  with more info

### DIFF
--- a/docs/guides/transpiler.ipynb
+++ b/docs/guides/transpiler.ipynb
@@ -353,6 +353,130 @@
   },
   {
    "cell_type": "markdown",
+   "id": "tld6t9qsk4",
+   "metadata": {},
+   "source": [
+    "### How stratification works\n",
+    "\n",
+    "Internally, the boxing pass manager groups entangling gates using a greedy algorithm that traverses the circuit DAG in topological order. Each two-qubit gate is placed in the **earliest group** whose qubits are not yet occupied. Barriers, existing box instructions, and measurements act as **delimiters**: when one is encountered on a qubit, any open group for that qubit is flushed, and subsequent gates on that qubit must start a new group.\n",
+    "\n",
+    "This means barriers give you direct control over which entangling gates share a box. No commutativity analysis is performed—the grouping respects the topological order of the circuit as-is."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1gm5d8zjr3ti",
+   "metadata": {},
+   "source": [
+    "### Why ``remove_barriers=\"after_stratification\"`` is the recommended default\n",
+    "\n",
+    "The default `\"after_stratification\"` mode is chosen because it combines two benefits:\n",
+    "\n",
+    "1. Barriers constrain how entangling gates are grouped (they act as delimiters during stratification).\n",
+    "2. Barriers are removed *before* {class}`~.AbsorbSingleQubitGates` runs, so single-qubit gates can still flow across former barrier positions and be absorbed into the nearest box.\n",
+    "\n",
+    "By contrast:\n",
+    "- ``\"never\"`` keeps barriers throughout, which traps single-qubit gates between a barrier and a box, preventing their absorption and leaving untwirled rotations in the circuit.\n",
+    "- ``\"immediately\"`` removes barriers before stratification, so they have no effect on grouping at all.\n",
+    "- ``\"finally\"`` is useful when you want barriers in the output circuit (e.g., for visualization), but be aware that single-qubit gates between a barrier and a box will not be absorbed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dcnbr1d0fak",
+   "metadata": {},
+   "source": [
+    "## Boxing ISA circuits with barriers\n",
+    "\n",
+    "Circuits with a repeated structure—Trotterized Hamiltonian simulations, variational ansatze, error amplification sequences—are typically built programmatically and then transpiled to ISA form. Manually adding boxes to an already-transpiled circuit is cumbersome, so the natural workflow is:\n",
+    "\n",
+    "1. Build the logical circuit, inserting **barriers** at the layer boundaries you want to become box boundaries.\n",
+    "2. Transpile to ISA. Qiskit's transpiler preserves barriers through routing and optimization.\n",
+    "3. Run {func}`~.generate_boxing_pass_manager` on the ISA circuit.\n",
+    "\n",
+    "Barriers are needed when the end of one layer does not cover all qubits: the greedy algorithm would otherwise place gates from the next layer—on those \"free\" qubits—into the same group. As a concrete example, consider a two-step Heisenberg ZZ simulation on a 5-qubit ring. Each Trotter step has three bond layers: even bonds ``(0,1), (2,3)``, odd bonds ``(1,2), (3,4)``, and the wrap bond ``(4,0)``. After the odd-bond layer, qubits 0 and 4 are both free. Without a barrier, the wrap bond ``(4,0)`` gets greedy-grouped with bonds from the *next* Trotter step that use those free qubits, mixing gates from different steps in the same box."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "kszvwbc7pzc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit.circuit import Parameter, QuantumCircuit\n",
+    "\n",
+    "n = 5  # 5-qubit ring: bonds (0,1), (1,2), (2,3), (3,4), (4,0)\n",
+    "dt = Parameter(\"dt\")\n",
+    "heisenberg = QuantumCircuit(n)\n",
+    "\n",
+    "for step in range(2):\n",
+    "    # Layer 1: even bonds (0,1) and (2,3)\n",
+    "    for i in range(0, n - 1, 2):\n",
+    "        heisenberg.rzz(dt, i, i + 1)\n",
+    "    heisenberg.barrier()\n",
+    "    # Layer 2: odd bonds (1,2) and (3,4) -- qubits 0 and 4 are now free\n",
+    "    for i in range(1, n - 1, 2):\n",
+    "        heisenberg.rzz(dt, i, i + 1)\n",
+    "    heisenberg.barrier()\n",
+    "    # Layer 3: wrap bond (4,0) -- both qubits were free after layer 2\n",
+    "    heisenberg.rzz(dt, n - 1, 0)\n",
+    "    if step < 1:\n",
+    "        heisenberg.barrier()  # separates the two Trotter steps\n",
+    "\n",
+    "heisenberg.measure_all()\n",
+    "\n",
+    "heisenberg.draw(\"mpl\", scale=0.7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "peqgvwbnxsl",
+   "metadata": {},
+   "source": [
+    "We transpile to ISA form, assuming the underlying device has CX as the native entangler. Note that the barriers survive transpilation and remain visible in the output circuit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wbvdpidcuhn",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit.transpiler import generate_preset_pass_manager\n",
+    "\n",
+    "preset_pm = generate_preset_pass_manager(\n",
+    "    basis_gates=[\"rz\", \"sx\", \"cx\"],\n",
+    "    coupling_map=[[0, 1], [1, 2], [2, 3], [3, 4], [4, 0]],\n",
+    "    optimization_level=1,\n",
+    ")\n",
+    "isa_circuit = preset_pm.run(heisenberg)\n",
+    "isa_circuit.draw(\"mpl\", scale=0.5, fold=200)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b5y3l4r3xp",
+   "metadata": {},
+   "source": [
+    "Now we apply the boxing pass manager to the ISA circuit. Each of the three bond layers becomes a separate box in each Trotter step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ccaoebqt3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "boxing_pm = generate_boxing_pass_manager()\n",
+    "boxed_isa = boxing_pm.run(isa_circuit)\n",
+    "boxed_isa.draw(\"mpl\", scale=0.5, fold=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d622fa1c",
    "metadata": {},
    "source": [
@@ -388,6 +512,85 @@
     "\n",
     "transpiled_circuit = preset_pass_manager.run(circuit)\n",
     "transpiled_circuit.draw(\"mpl\", scale=0.8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4k9ok8ip14a",
+   "metadata": {},
+   "source": [
+    "This pattern also combines naturally with the barrier-based ISA boxing workflow. The boxing pass manager runs as a post-scheduling step, after barriers from the original logical circuit have survived transpilation, so they guide stratification exactly as expected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5v5zjhiftji",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preset_pm = generate_preset_pass_manager(\n",
+    "    basis_gates=[\"rz\", \"sx\", \"cx\"],\n",
+    "    coupling_map=[[0, 1], [1, 2], [2, 3], [3, 4], [4, 0]],\n",
+    "    optimization_level=1,\n",
+    ")\n",
+    "preset_pm.post_scheduling = generate_boxing_pass_manager()\n",
+    "\n",
+    "boxed_heisenberg = preset_pm.run(heisenberg)\n",
+    "boxed_heisenberg.draw(\"mpl\", scale=0.5, fold=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ejdcnq671pw",
+   "metadata": {},
+   "source": [
+    "## Inspecting and modifying annotations\n",
+    "\n",
+    "After auto-boxing, you may want to inspect the annotations on specific boxes or adjust them—for example, to add noise injection to select boxes, remove annotations from some boxes, or change the twirling group. Samplomatic provides a set of utility functions in {mod}`samplomatic.utils` for this purpose. All of them return a **new circuit** without modifying the original.\n",
+    "\n",
+    "{func}`~.extend_annotations` appends one or more annotations to every box in the circuit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ets1otrd3w",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from samplomatic import InjectNoise, Twirl\n",
+    "from samplomatic.utils import extend_annotations\n",
+    "\n",
+    "boxed = generate_boxing_pass_manager().run(circuit_with_barrier)\n",
+    "\n",
+    "# Add InjectNoise to every box\n",
+    "with_noise = extend_annotations(boxed, InjectNoise(\"my_noise_ref\"))\n",
+    "with_noise.draw(\"mpl\", scale=0.8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8kqcs5nqlyl",
+   "metadata": {},
+   "source": "{func}`~.filter_annotations` keeps only annotations of specified types, removing the rest. {func}`~.replace_annotations` applies a callable to each annotation; the callable returns a list of annotations to substitute in its place (return ``[]`` to remove, a single-element list to replace, or a multi-element list to expand)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "kp7vc7yi7ba",
+   "metadata": {},
+   "outputs": [],
+   "source": "from samplomatic.utils import filter_annotations, replace_annotations\n\n# Keep only Twirl annotations, drop everything else\ntwirl_only = filter_annotations(with_noise, Twirl)\n\n# Replace the twirling group on every Twirl annotation\nupdated = replace_annotations(\n    twirl_only, lambda a: [Twirl(group=\"local_c1\")] if isinstance(a, Twirl) else [a]\n)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nlx8ix0fpo",
+   "metadata": {},
+   "source": [
+    "The general-purpose {func}`~.map_annotations` function accepts any callable mapping a list of annotations to a new list, giving you full control over per-box transformations. {func}`~.strip_annotations` is a convenience wrapper that removes all annotations from every box.\n",
+    "\n",
+    "For bulk changes like adding {class}`.InjectNoise` to all gate boxes, the ``inject_noise_targets`` parameter of {func}`~.generate_boxing_pass_manager` is still the most concise option. These utilities are most useful for selective per-box edits that the pass manager parameters do not cover."
    ]
   },
   {

--- a/docs/guides/transpiler.ipynb
+++ b/docs/guides/transpiler.ipynb
@@ -358,9 +358,18 @@
    "source": [
     "### How stratification works\n",
     "\n",
-    "Internally, the boxing pass manager groups entangling gates using a greedy algorithm that traverses the circuit DAG in topological order. Each two-qubit gate is placed in the **earliest group** whose qubits are not yet occupied. Barriers, existing box instructions, and measurements act as **delimiters**: when one is encountered on a qubit, any open group for that qubit is flushed, and subsequent gates on that qubit must start a new group.\n",
+    "The boxing pass manager runs two key passes in sequence:\n",
     "\n",
-    "This means barriers give you direct control over which entangling gates share a box. No commutativity analysis is performed—the grouping respects the topological order of the circuit as-is."
+    "1. **`GroupGatesIntoBoxes`** — stratifies entangling gates into boxes. Single-qubit gates are ignored entirely at this stage; only two-qubit gates are grouped.\n",
+    "2. **`AbsorbSingleQubitGates`** — absorbs each single-qubit gate into the nearest eligible box to its right.\n",
+    "\n",
+    "During stratification, `GroupGatesIntoBoxes` traverses the circuit DAG in topological order and places each two-qubit gate in the **earliest group** whose qubits are not yet occupied. Three kinds of instructions act as **delimiters** that flush the current group for their qubits, forcing subsequent gates on those qubits into a new group:\n",
+    "\n",
+    "- **Barriers**\n",
+    "- **Existing box instructions**\n",
+    "- **Measurements**\n",
+    "\n",
+    "Single-qubit gates are not delimiters — they have no effect on grouping and are left for `AbsorbSingleQubitGates` to handle. No commutativity analysis is currently performed; the grouping respects the topological order of the circuit as-is."
    ]
   },
   {
@@ -412,12 +421,12 @@
     "\n",
     "for step in range(2):\n",
     "    # Layer 1: even bonds (0,1) and (2,3)\n",
-    "    for i in range(0, n - 1, 2):\n",
-    "        heisenberg.rzz(dt, i, i + 1)\n",
+    "    for idx in range(0, n - 1, 2):\n",
+    "        heisenberg.rzz(dt, idx, idx + 1)\n",
     "    heisenberg.barrier()\n",
     "    # Layer 2: odd bonds (1,2) and (3,4) -- qubits 0 and 4 are now free\n",
-    "    for i in range(1, n - 1, 2):\n",
-    "        heisenberg.rzz(dt, i, i + 1)\n",
+    "    for idx in range(1, n - 1, 2):\n",
+    "        heisenberg.rzz(dt, idx, idx + 1)\n",
     "    heisenberg.barrier()\n",
     "    # Layer 3: wrap bond (4,0) -- both qubits were free after layer 2\n",
     "    heisenberg.rzz(dt, n - 1, 0)\n",
@@ -573,7 +582,9 @@
    "cell_type": "markdown",
    "id": "8kqcs5nqlyl",
    "metadata": {},
-   "source": "{func}`~.filter_annotations` keeps only annotations of specified types, removing the rest. {func}`~.replace_annotations` applies a callable to each annotation; the callable returns a list of annotations to substitute in its place (return ``[]`` to remove, a single-element list to replace, or a multi-element list to expand)."
+   "source": [
+    "{func}`~.filter_annotations` keeps only annotations of specified types, removing the rest. {func}`~.replace_annotations` applies a callable to each annotation; the callable returns a list of annotations to substitute in its place (return ``[]`` to remove, a single-element list to replace, or a multi-element list to expand)."
+   ]
   },
   {
    "cell_type": "code",
@@ -581,7 +592,17 @@
    "id": "kp7vc7yi7ba",
    "metadata": {},
    "outputs": [],
-   "source": "from samplomatic.utils import filter_annotations, replace_annotations\n\n# Keep only Twirl annotations, drop everything else\ntwirl_only = filter_annotations(with_noise, Twirl)\n\n# Replace the twirling group on every Twirl annotation\nupdated = replace_annotations(\n    twirl_only, lambda a: [Twirl(group=\"local_c1\")] if isinstance(a, Twirl) else [a]\n)"
+   "source": [
+    "from samplomatic.utils import filter_annotations, replace_annotations\n",
+    "\n",
+    "# Keep only Twirl annotations, drop everything else\n",
+    "twirl_only = filter_annotations(with_noise, Twirl)\n",
+    "\n",
+    "# Replace the twirling group on every Twirl annotation\n",
+    "updated = replace_annotations(\n",
+    "    twirl_only, lambda a: [Twirl(group=\"local_c1\")] if isinstance(a, Twirl) else [a]\n",
+    ")"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

The transpiler guide was updated with teh following additions:

  1. How stratification works — explains the greedy topological algorithm and how
  barriers/boxes/measurements act as group delimiters
  2. Why "after_stratification" is the recommended default — explains why barriers guide grouping but
  don't block single-qubit gate absorption
  3. Boxing ISA circuits with barriers — end-to-end workflow: build a Heisenberg ring circuit with
  intra-step barriers, transpile to ISA, then auto-box
  4. (Enhancement to existing section) Incorporate Samplomatic's pass manager into Qiskit's preset pass
  managers — adds a note + single-pipeline example reusing the Heisenberg circuit
  5. Inspecting and modifying annotations — showcases extend_annotations, filter_annotations, and
  replace_annotations from samplomatic.utils

## Details and comments
