### PR TITLE
Add delay to hashable nodes for `BoxKey`

### DIFF
--- a/samplomatic/utils/box_key.py
+++ b/samplomatic/utils/box_key.py
@@ -89,7 +89,7 @@ class BoxKey:
         """
         op = node.op
 
-        if not (node.is_standard_gate() or op.name in ["barrier", "measure"]):
+        if not (node.is_standard_gate() or op.name in ["barrier", "measure", "delay"]):
             raise ValueError(f"Hashing of {op.name} is not supported.")
 
         op_hashable = (op.name, op.num_qubits, op.num_clbits)

--- a/test/unit/test_utils/test_box_key.py
+++ b/test/unit/test_utils/test_box_key.py
@@ -112,7 +112,7 @@ def test_boxes_with_delays_barriers_measures():
     body = QuantumCircuit(1, 1)
     body.delay(42, 0)
     body.barrier()
-    # body.measure([0], [0]) # TODO: This errors...?
+    body.measure([0], [0])
     instr = CircuitInstruction(BoxOp(body), body.qubits, body.clbits)
 
     key1 = BoxKey(instr)

--- a/test/unit/test_utils/test_box_key.py
+++ b/test/unit/test_utils/test_box_key.py
@@ -113,7 +113,7 @@ def test_boxes_with_delays_barriers_measures():
     body.delay(42, 0)
     body.barrier()
     # body.measure([0], [0]) # TODO: This errors...?
-    instr = CircuitInstruction(BoxOp(body), body.qubits)
+    instr = CircuitInstruction(BoxOp(body), body.qubits, body.clbits)
 
     key1 = BoxKey(instr)
     key2 = BoxKey(deepcopy(instr))

--- a/test/unit/test_utils/test_box_key.py
+++ b/test/unit/test_utils/test_box_key.py
@@ -112,7 +112,7 @@ def test_boxes_with_delays_barriers_measures():
     body = QuantumCircuit(1, 1)
     body.delay(42, 0)
     body.barrier()
-    # body.measure([0], [0])
+    # body.measure([0], [0]) # TODO: This errors...?
     instr = CircuitInstruction(BoxOp(body), body.qubits)
 
     key1 = BoxKey(instr)

--- a/test/unit/test_utils/test_box_key.py
+++ b/test/unit/test_utils/test_box_key.py
@@ -112,7 +112,7 @@ def test_boxes_with_delays_barriers_measures():
     body = QuantumCircuit(1, 1)
     body.delay(42, 0)
     body.barrier()
-    body.measure([0], [0])
+    # body.measure([0], [0])
     instr = CircuitInstruction(BoxOp(body), body.qubits)
 
     key1 = BoxKey(instr)

--- a/test/unit/test_utils/test_box_key.py
+++ b/test/unit/test_utils/test_box_key.py
@@ -107,6 +107,19 @@ def test_equal_boxes_produce_equal_keys():
 
     assert key1 == key2
 
+def test_boxes_with_delays_barriers_measures():
+    """Test that BoxKeys can contain measures, barriers, and delays."""
+    body = QuantumCircuit(1)
+    body.delay(42, 0)
+    body.barrier()
+    body.measure_all()
+    instr = CircuitInstruction(BoxOp(body), body.qubits)
+
+    key1 = BoxKey(instr)
+    key2 = BoxKey(deepcopy(instr))
+
+    assert key1 == key2
+
 
 def test_different_boxes_produce_different_specs():
     """Test that different boxes produce different specifications."""

--- a/test/unit/test_utils/test_box_key.py
+++ b/test/unit/test_utils/test_box_key.py
@@ -109,10 +109,10 @@ def test_equal_boxes_produce_equal_keys():
 
 def test_boxes_with_delays_barriers_measures():
     """Test that BoxKeys can contain measures, barriers, and delays."""
-    body = QuantumCircuit(1)
+    body = QuantumCircuit(1, 1)
     body.delay(42, 0)
     body.barrier()
-    body.measure_all()
+    body.measure([0], [0])
     instr = CircuitInstruction(BoxOp(body), body.qubits)
 
     key1 = BoxKey(instr)


### PR DESCRIPTION
## Summary

This is needed to use `find_unique_box_instructions` when one of the boxes contains a delay.

## Details and comments

I'm not yet sure if there are larger consequences of this, but eyeballing it my guess is that this is okay. If there's a better solution to this I'm open to suggestions!