### PR TITLE
Fix samplex.draw() arrow directions

### DIFF
--- a/samplomatic/visualization/graphviz_layout.py
+++ b/samplomatic/visualization/graphviz_layout.py
@@ -124,8 +124,10 @@ def render_bezier_spline(
     segments[:, 0, :] = control_points[:-1:3]
     segments[:, 1:, :] = control_points[1:].reshape(num_segments, 3, 2)
 
-    # define the bezier transformation
-    steps = np.linspace(0, 1, steps_per_segment, endpoint=True)
+    # define the bezier transformation; endpoint=False avoids duplicate points at segment
+    # boundaries (the endpoint of segment k equals the startpoint of segment k+1), which
+    # would cause angleref="previous" to compute a zero-length direction at those positions
+    steps = np.linspace(0, 1, steps_per_segment, endpoint=False)
     basis = np.stack(
         [
             (1 - steps) ** 3,
@@ -136,5 +138,6 @@ def render_bezier_spline(
         axis=1,
     )
 
-    # perform the rendering
-    return np.einsum("sf,nfd->nsd", basis, segments).reshape(-1, 2)
+    # perform the rendering and append the final endpoint of the last segment
+    rendered = np.einsum("sf,nfd->nsd", basis, segments).reshape(-1, 2)
+    return np.vstack([rendered, control_points[-1]])


### PR DESCRIPTION
## Summary

Fixes spurious arrows being drawn in the wrong direction. You can see in this example only one arrow is wrong:

<img width="1189" height="605" alt="image" src="https://github.com/user-attachments/assets/0c037c52-6da8-4327-8386-7b120027125d" />


AI tool used: claude opus+sonnet 4.6

impressively, my prompt was giving it a screenshot of the problem and telling it to figure out why some arrows look funny

## Details and comments

I got claude on the case, and it found the problem is kinda obvious in retrospect, but also pretty tricky/subtle to track down:

> When plotting a samplex/pre_samplex DAG with plot_graph(), 2 out of ~20 edge arrows point backwards. The root cause is duplicate adjacent points at Bezier segment boundaries in render_bezier_spline.
>     Each segment is rendered with np.linspace(0, 1, steps_per_segment, endpoint=True), so the last point of segment k (t=1.0) is identical to the first point of segment k+1 (t=0.0). After .reshape(-1, 2), these duplicates sit adjacent in the array. When ARROW_POS=0.7 causes mid_point_idx to land on a duplicate, angleref="previous" computes the direction from two identical positions → (0,0) → wrong arrow.
>     With steps_per_segment=5, boundaries are at every 5th index. For an edge with 3 Bezier segments, mid_point_idx = int(15 * 0.7) = 10 — exactly a duplicate (point 9 = end of segment 1, point 10 = start of segment 2).


So basically, the arrow direction is undefined every time plotly infers the direction of the arrow from the `int(num_bezier_segments * 5 * 0.7)`'th edge coordinate.

<img width="1133" height="588" alt="image" src="https://github.com/user-attachments/assets/8c642f31-5fb6-4f4c-b940-0433f4d21086" />
