### PR TITLE
Add LookupTableStore to SSV 4's HeaderV2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -60,7 +60,7 @@ The core pipeline is: **annotated circuit** → `build()` → **(template circui
 - **Ruff rules**: pydocstyle (D), pycodestyle (E), pyflakes (F), isort (I), private-member-access (SLF), pyupgrade (UP)
 - All files require Apache 2.0 license headers (enforced by pre-commit)
 - When modifying a file, update its copyright year to the current calendar year (e.g. `(C) Copyright IBM 2025, 2026.`)
-- Python 3.10+ (use `X | Y` union syntax, etc.)
+- Python 3.10+ (use `X | Y` union syntax, etc.); do **not** use `from __future__ import annotations` — use string literals for the rare forward-reference case instead
 - **Import removal hazard**: The pre-commit hook runs `ruff --fix`, which auto-removes unused imports (rule F401). When adding new imports, always add the corresponding usage in the same edit to avoid the import being stripped at commit time. If you need to add imports incrementally, use a `# noqa: F401` comment and remove it once the usage is in place.
 
 ## Testing

--- a/samplomatic/serialization/__init__.py
+++ b/samplomatic/serialization/__init__.py
@@ -62,7 +62,8 @@ The SSV history is summarized in the following table:
      - 0.18.0
      - Added :class:`~PropagateLocalPauliNode` and support for RZZ in
        :class:`~PauliPastCliffordNode`, :class:`~PropagateLocalC1Node`, and
-       :class:`~UniformLocalC1`.
+       :class:`~UniformLocalC1`; added lookup table store infrastructure to the
+       serialization header.
 
 Backwards compatibility
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/samplomatic/serialization/lookup_table_store.py
+++ b/samplomatic/serialization/lookup_table_store.py
@@ -87,8 +87,6 @@ class LookupTableStore:
     def from_json(cls, data: str) -> "LookupTableStore":
         """Deserialize a store from a JSON string.
 
-        Arrays stored as ``int64`` are restored to ``np.intp`` dtype.
-
         Args:
             data: A JSON string produced by :meth:`to_json`.
 
@@ -97,11 +95,7 @@ class LookupTableStore:
         """
         store = cls()
         for key, array_json in orjson.loads(data).items():
-            array = array_from_json(array_json)
-            # Restore int64 back to np.intp
-            if array.dtype == np.dtype(np.int64):
-                array = array.astype(np.intp)
-            store._store[key] = array  # noqa: SLF001
+            store._store[key] = array_from_json(array_json)  # noqa: SLF001
         return store
 
 

--- a/samplomatic/serialization/lookup_table_store.py
+++ b/samplomatic/serialization/lookup_table_store.py
@@ -1,0 +1,138 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Lookup table store for samplex serialization."""
+
+import contextlib
+import contextvars
+from collections.abc import Generator
+
+import numpy as np
+import orjson
+
+from .utils import array_from_json, array_to_json
+
+
+class LookupTableStore:
+    """A named store of numpy arrays for use during samplex serialization.
+
+    Keys have the form ``"{node_type_id}:{name}"`` (e.g. ``"N13:cx"``), which scopes
+    tables to node types so that different node types cannot accidentally share data.
+
+    Node serializers should call :func:`get_lookup_table_store` to access the active store
+    during serialization/deserialization, then call :meth:`register` or :meth:`lookup`.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, np.ndarray] = {}
+
+    def register(self, node_type_id: str, name: str, array: np.ndarray) -> str:
+        """Store an array and return its key.
+
+        Args:
+            node_type_id: The serializer's type ID (e.g. ``"N13"``).
+            name: A name for the table within that node type (e.g. ``"cx"``).
+            array: The numpy array to store. Last-write-wins for identical keys.
+
+        Returns:
+            The key under which the array is stored (``"{node_type_id}:{name}"``).
+        """
+        key = f"{node_type_id}:{name}"
+        self._store[key] = array
+        return key
+
+    def lookup(self, key: str) -> np.ndarray:
+        """Retrieve an array by key.
+
+        Args:
+            key: The key previously returned by :meth:`register`.
+
+        Returns:
+            The stored array.
+
+        Raises:
+            KeyError: If no array is registered under ``key``.
+        """
+        return self._store[key]
+
+    def __bool__(self) -> bool:
+        return bool(self._store)
+
+    def to_json(self) -> str:
+        """Serialize the store to a JSON string.
+
+        Arrays with ``np.intp`` dtype are cast to ``int64`` for portability.
+
+        Returns:
+            A JSON string encoding all stored arrays.
+        """
+        serialized = {}
+        for key, array in self._store.items():
+            # Cast np.intp to int64 for portability (np.intp is platform-dependent)
+            if array.dtype == np.dtype(np.intp):
+                array = array.astype(np.int64)
+            serialized[key] = array_to_json(array)
+        return orjson.dumps(serialized).decode("utf-8")
+
+    @classmethod
+    def from_json(cls, data: str) -> "LookupTableStore":
+        """Deserialize a store from a JSON string.
+
+        Arrays stored as ``int64`` are restored to ``np.intp`` dtype.
+
+        Args:
+            data: A JSON string produced by :meth:`to_json`.
+
+        Returns:
+            A :class:`LookupTableStore` populated with the deserialized arrays.
+        """
+        store = cls()
+        for key, array_json in orjson.loads(data).items():
+            array = array_from_json(array_json)
+            # Restore int64 back to np.intp
+            if array.dtype == np.dtype(np.int64):
+                array = array.astype(np.intp)
+            store._store[key] = array  # noqa: SLF001
+        return store
+
+
+_LOOKUP_TABLE_STORE: contextvars.ContextVar[LookupTableStore | None] = contextvars.ContextVar(
+    "_LOOKUP_TABLE_STORE", default=None
+)
+
+
+def get_lookup_table_store() -> LookupTableStore | None:
+    """Return the active :class:`LookupTableStore`, or ``None`` if not set.
+
+    Node serializers call this during serialization/deserialization to access the store
+    without needing it passed through function arguments.
+    """
+    return _LOOKUP_TABLE_STORE.get()
+
+
+@contextlib.contextmanager
+def active_lookup_table_store(store: LookupTableStore) -> Generator[LookupTableStore, None, None]:
+    """Context manager that sets ``store`` as the active :class:`LookupTableStore`.
+
+    On exit the previous value is restored, even if an exception is raised.
+
+    Args:
+        store: The store to activate.
+
+    Yields:
+        The same ``store`` that was passed in.
+    """
+    token = _LOOKUP_TABLE_STORE.set(store)
+    try:
+        yield store
+    finally:
+        _LOOKUP_TABLE_STORE.reset(token)

--- a/samplomatic/serialization/samplex_serializer.py
+++ b/samplomatic/serialization/samplex_serializer.py
@@ -43,6 +43,7 @@ from ..samplex import Samplex
 from ..samplex.nodes import Node
 from ..ssv import SSV
 from .distribution_serializers import *  # noqa: F403
+from .lookup_table_store import LookupTableStore, active_lookup_table_store
 from .node_serializers import *  # noqa: F403
 from .parameter_expression_serializer import ParameterExpressionTableSerializer
 from .specification_serializers import deserialize_specifications, serialize_specifications
@@ -79,6 +80,16 @@ class HeaderV1(Header):
         )
 
 
+class HeaderV2(HeaderV1):
+    lookup_tables: str
+
+    def from_samplex(samplex: Samplex, ssv: int = SSV, store: LookupTableStore | None = None):
+        return HeaderV2(
+            **HeaderV1.from_samplex(samplex, ssv=ssv),
+            lookup_tables=(store.to_json() if store is not None else LookupTableStore().to_json()),
+        )
+
+
 def serialize_passthrough_params(data: tuple[list[int], list[int]] | None) -> str:
     if data is None:
         return "None"
@@ -112,7 +123,6 @@ def samplex_to_json(samplex, filename=None, ssv=SSV):
     Raises:
         SerializationError: If ``ssv`` is incompatible.
     """
-    header = HeaderV1.from_samplex(samplex, ssv=ssv)
 
     def serialize_node(node: Node):
         try:
@@ -121,6 +131,18 @@ def samplex_to_json(samplex, filename=None, ssv=SSV):
             raise SerializationError(f"Node type {type(node)} cannot be serialized.") from exc
         return TypeSerializer.TYPE_ID_REGISTRY[type_id].serialize(node, ssv)
 
+    if ssv >= 4:
+        # rustworkx calls node_attrs before graph_attrs, so the store is fully
+        # populated by the time the lambda fires.
+        with active_lookup_table_store(LookupTableStore()) as store:
+            return node_link_json(
+                samplex.graph,
+                path=filename,
+                graph_attrs=lambda _: HeaderV2.from_samplex(samplex, ssv=ssv, store=store),
+                node_attrs=serialize_node,
+            )
+
+    header = HeaderV1.from_samplex(samplex, ssv=ssv)
     return node_link_json(
         samplex.graph,
         path=filename,
@@ -156,5 +178,12 @@ def samplex_from_json(json_data: str) -> Samplex:
     Raises:
         SerializationError: If the SSV specified in the json string is unsupported.
     """
-    samplex_graph = parse_node_link_json(json_data, node_attrs=TypeSerializer.deserialize)
-    return _samplex_from_graph(samplex_graph)
+    raw_attrs = orjson.loads(json_data).get("attrs", {})
+    ssv = int(raw_attrs.get("ssv", 1))
+    if ssv >= 4:
+        store = LookupTableStore.from_json(raw_attrs["lookup_tables"])
+    else:
+        store = LookupTableStore()
+    with active_lookup_table_store(store):
+        samplex_graph = parse_node_link_json(json_data, node_attrs=TypeSerializer.deserialize)
+        return _samplex_from_graph(samplex_graph)

--- a/test/unit/test_serialization/test_lookup_table_store.py
+++ b/test/unit/test_serialization/test_lookup_table_store.py
@@ -89,12 +89,12 @@ def test_json_round_trip(arr):
     assert result.shape == arr.shape
 
 
-def test_json_round_trip_intp_dtype_preserved():
+def test_json_round_trip_intp_serialized_as_int64():
     arr = np.array([0, 1, 2], dtype=np.intp)
     store = LookupTableStore()
     store.register("N7", "idx", arr)
     restored = LookupTableStore.from_json(store.to_json())
-    assert restored.lookup("N7:idx").dtype == np.dtype(np.intp)
+    assert restored.lookup("N7:idx").dtype == np.dtype(np.int64)
 
 
 def test_json_round_trip_empty():

--- a/test/unit/test_serialization/test_lookup_table_store.py
+++ b/test/unit/test_serialization/test_lookup_table_store.py
@@ -1,0 +1,120 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import numpy as np
+import pytest
+
+from samplomatic.serialization.lookup_table_store import (
+    LookupTableStore,
+    active_lookup_table_store,
+    get_lookup_table_store,
+)
+
+
+def test_register_returns_key():
+    store = LookupTableStore()
+    arr = np.array([1, 2, 3], dtype=np.int64)
+    key = store.register("N1", "foo", arr)
+    assert key == "N1:foo"
+
+
+def test_lookup_success():
+    store = LookupTableStore()
+    arr = np.array([10, 20], dtype=np.int64)
+    store.register("N2", "bar", arr)
+    result = store.lookup("N2:bar")
+    np.testing.assert_array_equal(result, arr)
+
+
+def test_lookup_missing_raises():
+    store = LookupTableStore()
+    with pytest.raises(KeyError):
+        store.lookup("N99:missing")
+
+
+def test_last_write_wins():
+    store = LookupTableStore()
+    arr1 = np.array([1, 2], dtype=np.int64)
+    arr2 = np.array([3, 4], dtype=np.int64)
+    store.register("N3", "tbl", arr1)
+    store.register("N3", "tbl", arr2)
+    np.testing.assert_array_equal(store.lookup("N3:tbl"), arr2)
+
+
+def test_idempotent_registration_same_content():
+    store = LookupTableStore()
+    arr = np.array([5, 6, 7], dtype=np.int64)
+    key1 = store.register("N4", "t", arr)
+    key2 = store.register("N4", "t", arr)
+    assert key1 == key2
+    np.testing.assert_array_equal(store.lookup(key1), arr)
+
+
+def test_bool_empty():
+    store = LookupTableStore()
+    assert not store
+
+
+def test_bool_nonempty():
+    store = LookupTableStore()
+    store.register("N5", "x", np.array([1], dtype=np.int64))
+    assert store
+
+
+@pytest.mark.parametrize(
+    "arr",
+    [
+        np.array([[1, 2], [3, 4]], dtype=np.int64),
+        np.array([1.0 + 2j, 3.0 - 4j], dtype=np.complex128),
+        np.array([0, 1, 255], dtype=np.uint8),
+        np.array([[0, 1], [2, 3]], dtype=np.intp),
+    ],
+)
+def test_json_round_trip(arr):
+    store = LookupTableStore()
+    store.register("N6", "arr", arr)
+    json_str = store.to_json()
+    restored = LookupTableStore.from_json(json_str)
+    result = restored.lookup("N6:arr")
+    np.testing.assert_array_equal(result, arr)
+    assert result.shape == arr.shape
+
+
+def test_json_round_trip_intp_dtype_preserved():
+    arr = np.array([0, 1, 2], dtype=np.intp)
+    store = LookupTableStore()
+    store.register("N7", "idx", arr)
+    restored = LookupTableStore.from_json(store.to_json())
+    assert restored.lookup("N7:idx").dtype == np.dtype(np.intp)
+
+
+def test_json_round_trip_empty():
+    store = LookupTableStore()
+    restored = LookupTableStore.from_json(store.to_json())
+    assert not restored
+
+
+def test_context_var_accessor_none_by_default():
+    assert get_lookup_table_store() is None
+
+
+def test_context_var_accessor_returns_store():
+    store = LookupTableStore()
+    with active_lookup_table_store(store):
+        assert get_lookup_table_store() is store
+
+
+def test_context_var_reset_after_use():
+    store = LookupTableStore()
+    with active_lookup_table_store(store):
+        pass
+    assert get_lookup_table_store() is None


### PR DESCRIPTION
## Summary

This PR adds a new header version (HeaderV2) to the SSV format, and makes it the default header in the upcoming SSV 4. The new header adds a new field that is able to store a hashmap of array lookup tables. Nodes and distributions are able to store lookup tables into this table.

The motivation for this change is to decrease the rate at which we need to introduce new SSV versions when existing nodes are being extended. For example, if a propagation node adds support to propagate a new gate, since the lookup tables are now encoded in the serialed form, the version of samplomatic receiving the node need not itself know about the new propagation scheme.

## Details and comments
