### PR TITLE
Expose the Samplex' output passthrough parameters

### DIFF
--- a/changelog.d/367.added.md
+++ b/changelog.d/367.added.md
@@ -1,1 +1,5 @@
-Added `Samplex.evaluate_passthrough_parameters`, which returns the template parameter indices and evaluated values for the subset of template parameters whose values are deterministic functions of the input parameters.
+Exposed three primitives that together let consumers of `build()` evaluate deterministic template parameters (e.g., `RZZ` angles) without invoking `Samplex.sample`:
+
+- `Samplex.param_table` — return the underlying `ParameterExpressionTable`.
+- `Samplex.passthrough_params` — a tuple `(template_idxs, expression_idxs)` mapping each passthrough template parameter to its expression-table index.
+- `ParameterExpressionTable.evaluate` — gained an optional `indices` argument so callers can evaluate only a chosen subset of the table's expressions.

--- a/changelog.d/367.added.md
+++ b/changelog.d/367.added.md
@@ -1,0 +1,1 @@
+Added `Samplex.evaluate_passthrough_parameters`, which returns the template parameter indices and evaluated values for the subset of template parameters whose values are deterministic functions of the input parameters.

--- a/samplomatic/samplex/parameter_expression_table.py
+++ b/samplomatic/samplex/parameter_expression_table.py
@@ -1,6 +1,6 @@
 # This code is a Qiskit project.
 #
-# (C) Copyright IBM 2025.
+# (C) Copyright IBM 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,8 @@
 # that they have been altered from the originals.
 
 """ParameterExpressionTable"""
+
+from collections.abc import Sequence
 
 import numpy as np
 from qiskit.circuit import ParameterVectorElement
@@ -98,12 +100,20 @@ class ParameterExpressionTable(metaclass=Serializable):
         """The number of parameter expressions to evaluate; the return size of :meth:`~evaluate`."""
         return len(self._expressions)
 
-    def evaluate(self, parameter_values: ParamValues) -> np.ndarray:
-        r"""Return one numeric value for each expression.
+    def evaluate(
+        self,
+        parameter_values: ParamValues,
+        indices: Sequence[ParamIndex] | None = None,
+    ) -> np.ndarray:
+        r"""Return numeric values for the table's expressions.
 
         Args:
             parameter_values: The parameter values, either as a map from parameters to their values,
                 or just the values in parameter-sorted order (see :attr:`~parameters`\).
+            indices: An optional sequence of expression indices to evaluate. When ``None``, all
+                expressions are evaluated in order. When provided, only the expressions at the given
+                indices are evaluated, in the given order, so
+                ``len(returned_array) == len(indices)``.
 
         Returns:
             An array of evaluated expressions.
@@ -120,9 +130,13 @@ class ParameterExpressionTable(metaclass=Serializable):
         if not isinstance(parameter_values, dict):
             parameter_values = dict(zip(self.parameters, parameter_values))
 
+        expressions = (
+            self._expressions if indices is None else [self._expressions[i] for i in indices]
+        )
+
         try:
             return np.array(
-                [expression.bind_all(parameter_values) for expression in self._expressions],
+                [expression.bind_all(parameter_values) for expression in expressions],
                 dtype=float,
             )
         except KeyError as exc:

--- a/samplomatic/samplex/samplex.py
+++ b/samplomatic/samplex/samplex.py
@@ -32,7 +32,6 @@ from ..aliases import (
     ParameterExpression,
     ParamIndex,
     ParamSpec,
-    ParamValues,
     RegisterName,
     Self,
 )
@@ -144,6 +143,18 @@ class Samplex:
         return f"Samplex(<{len(self.graph)} nodes>)\n  Inputs:\n{inputs}\n  Outputs:\n{outputs}"
 
     @property
+    def param_table(self) -> ParameterExpressionTable:
+        """The :class:`~.ParameterExpressionTable` owning this samplex's parameter expressions.
+
+        Parametric nodes added to the samplex reference entries of this table by index, and
+        :meth:`~.sample` evaluates the table at sampling time. Combined with
+        :attr:`~.passthrough_params`, callers can evaluate just the deterministic subset of template
+        parameters (e.g., :class:`~qiskit.circuit.library.RZZGate` angles) without invoking
+        :meth:`~.sample`. See also :attr:`~.parameters` and :meth:`~.append_parameter_expression`.
+        """
+        return self._param_table
+
+    @property
     def parameters(self) -> list[Parameter]:
         """The sorted parameters expecting values at sampling time."""
         return self._param_table.parameters
@@ -152,6 +163,24 @@ class Samplex:
     def num_parameters(self) -> int:
         """The number of parameters expected at sampling time."""
         return self._param_table.num_parameters
+
+    @property
+    def passthrough_params(self) -> tuple[np.ndarray, np.ndarray]:
+        r"""The index mapping that drives passthrough template parameters.
+
+        Returns a pair of equal-length, positionally aligned integer arrays
+        ``(template_idxs, expression_idxs)``: the value at template parameter index
+        ``template_idxs[i]`` is set during :meth:`~.sample` from the value of the
+        :attr:`~.param_table` expression at index ``expression_idxs[i]`` (see
+        :meth:`~.set_passthrough_params`).
+
+        Both arrays are empty if no passthrough parameters are registered. The returned
+        arrays are independent copies of the internal state.
+        """
+        if self._passthrough_params is None:
+            return np.empty(0, dtype=int), np.empty(0, dtype=int)
+        template_idxs, expression_idxs = self._passthrough_params
+        return np.asarray(template_idxs, dtype=int), np.asarray(expression_idxs, dtype=int)
 
     def append_parameter_expression(self, expression: ParameterExpression) -> ParamIndex:
         """Add a parameter expression to the samplex.
@@ -188,34 +217,6 @@ class Samplex:
             param_exp_idxs.append(self.append_parameter_expression(exp))
         self._passthrough_params = (param_idxs, param_exp_idxs)
         return max(param_idxs)
-
-    def evaluate_passthrough_parameters(
-        self, parameter_values: ParamValues
-    ) -> tuple[np.ndarray, np.ndarray]:
-        r"""Evaluate the input expressions controlling passthrough template parameters.
-
-        Some template circuit parameters are deterministic functions of the input parameters: those
-        whose values flow directly through this samplex without being touched by virtual gate
-        propagation or sampling (see :meth:`~.set_passthrough_params`). This method evaluates
-        the controlling expressions for those template parameters only, without invoking
-        :meth:`~.sample`.
-
-        Args:
-            parameter_values: Values for the input parameters, in the same form accepted by
-                :meth:`~.sample`: either a sequence in :attr:`~.parameters` order, or a
-                mapping from :class:`~qiskit.circuit.Parameter` to value.
-
-        Returns:
-            A pair ``(template_idxs, values)`` of equal-length arrays.
-            ``template_idxs`` (integer dtype) holds the template parameter indices and
-            ``values`` (float dtype) holds the corresponding evaluated expression values.
-            Both arrays are empty if no passthrough parameters are registered.
-        """
-        if self._passthrough_params is None:
-            return np.empty(0, dtype=int), np.empty(0, dtype=float)
-        template_idxs, expression_idxs = self._passthrough_params
-        evaluated = self._param_table.evaluate(parameter_values)
-        return np.asarray(template_idxs, dtype=int), evaluated[expression_idxs]
 
     def add_input(self, specification: Specification):
         """Add a sampling input to this samplex.

--- a/samplomatic/samplex/samplex.py
+++ b/samplomatic/samplex/samplex.py
@@ -143,6 +143,16 @@ class Samplex:
         return f"Samplex(<{len(self.graph)} nodes>)\n  Inputs:\n{inputs}\n  Outputs:\n{outputs}"
 
     @property
+    def param_table(self) -> ParameterExpressionTable:
+        """The :class:`~.ParameterExpressionTable` owning this samplex's parameter expressions.
+
+        Parametric nodes added to the samplex reference entries of this table by index, and
+        :meth:`~.sample` evaluates the table at sampling time. See also :attr:`~.parameters`
+        and :meth:`~.append_parameter_expression`.
+        """
+        return self._param_table
+
+    @property
     def parameters(self) -> list[Parameter]:
         """The sorted parameters expecting values at sampling time."""
         return self._param_table.parameters

--- a/samplomatic/samplex/samplex.py
+++ b/samplomatic/samplex/samplex.py
@@ -32,6 +32,7 @@ from ..aliases import (
     ParameterExpression,
     ParamIndex,
     ParamSpec,
+    ParamValues,
     RegisterName,
     Self,
 )
@@ -143,16 +144,6 @@ class Samplex:
         return f"Samplex(<{len(self.graph)} nodes>)\n  Inputs:\n{inputs}\n  Outputs:\n{outputs}"
 
     @property
-    def param_table(self) -> ParameterExpressionTable:
-        """The :class:`~.ParameterExpressionTable` owning this samplex's parameter expressions.
-
-        Parametric nodes added to the samplex reference entries of this table by index, and
-        :meth:`~.sample` evaluates the table at sampling time. See also :attr:`~.parameters`
-        and :meth:`~.append_parameter_expression`.
-        """
-        return self._param_table
-
-    @property
     def parameters(self) -> list[Parameter]:
         """The sorted parameters expecting values at sampling time."""
         return self._param_table.parameters
@@ -197,6 +188,34 @@ class Samplex:
             param_exp_idxs.append(self.append_parameter_expression(exp))
         self._passthrough_params = (param_idxs, param_exp_idxs)
         return max(param_idxs)
+
+    def evaluate_passthrough_parameters(
+        self, parameter_values: ParamValues
+    ) -> tuple[np.ndarray, np.ndarray]:
+        r"""Evaluate the input expressions controlling passthrough template parameters.
+
+        Some template circuit parameters are deterministic functions of the input parameters: those
+        whose values flow directly through this samplex without being touched by virtual gate
+        propagation or sampling (see :meth:`~.set_passthrough_params`). This method evaluates
+        the controlling expressions for those template parameters only, without invoking
+        :meth:`~.sample`.
+
+        Args:
+            parameter_values: Values for the input parameters, in the same form accepted by
+                :meth:`~.sample`: either a sequence in :attr:`~.parameters` order, or a
+                mapping from :class:`~qiskit.circuit.Parameter` to value.
+
+        Returns:
+            A pair ``(template_idxs, values)`` of equal-length arrays.
+            ``template_idxs`` (integer dtype) holds the template parameter indices and
+            ``values`` (float dtype) holds the corresponding evaluated expression values.
+            Both arrays are empty if no passthrough parameters are registered.
+        """
+        if self._passthrough_params is None:
+            return np.empty(0, dtype=int), np.empty(0, dtype=float)
+        template_idxs, expression_idxs = self._passthrough_params
+        evaluated = self._param_table.evaluate(parameter_values)
+        return np.asarray(template_idxs, dtype=int), evaluated[expression_idxs]
 
     def add_input(self, specification: Specification):
         """Add a sampling input to this samplex.

--- a/samplomatic/serialization/samplex_serializer.py
+++ b/samplomatic/serialization/samplex_serializer.py
@@ -72,7 +72,7 @@ class HeaderV1(Header):
             ssv=str(ssv),
             samplomatic_version=samplomatic_version,
             param_table=orjson.dumps(
-                ParameterExpressionTableSerializer.serialize(samplex.param_table, ssv=ssv)
+                ParameterExpressionTableSerializer.serialize(samplex._param_table, ssv=ssv)  # noqa: SLF001
             ).decode("utf-8"),
             input_specification=serialize_specifications(samplex._input_specifications, ssv=ssv),  # noqa: SLF001
             output_specification=serialize_specifications(samplex._output_specifications, ssv=ssv),  # noqa: SLF001

--- a/samplomatic/serialization/samplex_serializer.py
+++ b/samplomatic/serialization/samplex_serializer.py
@@ -72,7 +72,7 @@ class HeaderV1(Header):
             ssv=str(ssv),
             samplomatic_version=samplomatic_version,
             param_table=orjson.dumps(
-                ParameterExpressionTableSerializer.serialize(samplex._param_table, ssv=ssv)  # noqa: SLF001
+                ParameterExpressionTableSerializer.serialize(samplex.param_table, ssv=ssv)
             ).decode("utf-8"),
             input_specification=serialize_specifications(samplex._input_specifications, ssv=ssv),  # noqa: SLF001
             output_specification=serialize_specifications(samplex._output_specifications, ssv=ssv),  # noqa: SLF001

--- a/test/unit/test_samplex/test_parameter_expression_table.py
+++ b/test/unit/test_samplex/test_parameter_expression_table.py
@@ -1,6 +1,6 @@
 # This code is a Qiskit project.
 #
-# (C) Copyright IBM 2025.
+# (C) Copyright IBM 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -84,6 +84,40 @@ def test_evaluate():
 
     assert np.array_equal(table.evaluate([1, 2, 3]), np.array([3.0, 5, 1, 2, 1, 6]))
     assert np.array_equal(table.evaluate({a: 2, b: 3, c: 4}), np.array([5.0, 7, 2, 3, 2, 24]))
+
+
+def test_evaluate_with_indices():
+    """Test the evaluate method's optional ``indices`` argument."""
+    a = Parameter("a")
+    b = Parameter("b")
+    c = Parameter("c")
+    table = ParameterExpressionTable()
+
+    table.append(a + b)
+    table.append(b + c)
+    table.append(a)
+    table.append(b)
+    table.append(a)
+    table.append(a * b * c)
+
+    full = table.evaluate([1, 2, 3])
+
+    # Subset selection preserves caller-supplied order.
+    np.testing.assert_array_equal(table.evaluate([1, 2, 3], indices=[5, 0, 2]), full[[5, 0, 2]])
+
+    # Dict-form values produce identical results.
+    np.testing.assert_array_equal(
+        table.evaluate({a: 1, b: 2, c: 3}, indices=[5, 0, 2]),
+        full[[5, 0, 2]],
+    )
+
+    # Empty indices yields a length-0 float array (not ``None``).
+    empty = table.evaluate([1, 2, 3], indices=[])
+    assert empty.shape == (0,) and empty.dtype == np.float64
+
+    # Out-of-range indices propagate as IndexError (caller's responsibility).
+    with pytest.raises(IndexError):
+        table.evaluate([1, 2, 3], indices=[99])
 
 
 def test_evaluate_fails():

--- a/test/unit/test_samplex/test_samplex.py
+++ b/test/unit/test_samplex/test_samplex.py
@@ -1,6 +1,6 @@
 # This code is a Qiskit project.
 #
-# (C) Copyright IBM 2025.
+# (C) Copyright IBM 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -21,7 +21,7 @@ from qiskit.circuit import Parameter
 
 from samplomatic.exceptions import SamplexConstructionError, SamplexRuntimeError
 from samplomatic.optionals import HAS_PLOTLY
-from samplomatic.samplex import Samplex
+from samplomatic.samplex import ParameterExpressionTable, Samplex
 from samplomatic.samplex.samplex import wait_with_raise
 from samplomatic.tensor_interface import PauliLindbladMapSpecification, TensorSpecification
 from samplomatic.virtual_registers import PauliRegister, U2Register
@@ -82,6 +82,24 @@ class TestBasic:
         assert samplex.append_parameter_expression(a + b + Parameter("c")) == 3
 
         assert samplex.num_parameters == 3
+
+    def test_param_table_property(self):
+        """Test that the public ``param_table`` property exposes the underlying table."""
+        samplex = Samplex()
+        table = samplex.param_table
+        assert isinstance(table, ParameterExpressionTable)
+        assert table.num_expressions == 0
+
+        a = Parameter("a")
+        b = Parameter("b")
+        samplex.append_parameter_expression(a)
+        samplex.append_parameter_expression(a + b)
+
+        assert samplex.param_table is table
+        assert table.num_expressions == 2
+        assert samplex.param_table.parameters == samplex.parameters
+
+        np.testing.assert_array_equal(samplex.param_table.evaluate([1.0, 2.0]), [1.0, 3.0])
 
     def test_add_output(self):
         """Test that we can add an output."""

--- a/test/unit/test_samplex/test_samplex.py
+++ b/test/unit/test_samplex/test_samplex.py
@@ -21,7 +21,7 @@ from qiskit.circuit import Parameter
 
 from samplomatic.exceptions import SamplexConstructionError, SamplexRuntimeError
 from samplomatic.optionals import HAS_PLOTLY
-from samplomatic.samplex import ParameterExpressionTable, Samplex
+from samplomatic.samplex import Samplex
 from samplomatic.samplex.samplex import wait_with_raise
 from samplomatic.tensor_interface import PauliLindbladMapSpecification, TensorSpecification
 from samplomatic.virtual_registers import PauliRegister, U2Register
@@ -83,23 +83,35 @@ class TestBasic:
 
         assert samplex.num_parameters == 3
 
-    def test_param_table_property(self):
-        """Test that the public ``param_table`` property exposes the underlying table."""
-        samplex = Samplex()
-        table = samplex.param_table
-        assert isinstance(table, ParameterExpressionTable)
-        assert table.num_expressions == 0
+    def test_evaluate_passthrough_parameters(self):
+        """Test the public introspection method for passthrough parameter values."""
+        from samplomatic.exceptions import ParameterError
 
+        # Empty samplex returns two zero-length arrays of the documented dtypes.
+        empty = Samplex()
+        idxs, values = empty.evaluate_passthrough_parameters({})
+        assert idxs.shape == (0,) and idxs.dtype == np.int64
+        assert values.shape == (0,) and values.dtype == np.float64
+
+        # Wire up two passthrough template parameters: index 4 <- a, index 7 <- 2*a + b.
+        samplex = Samplex()
         a = Parameter("a")
         b = Parameter("b")
-        samplex.append_parameter_expression(a)
-        samplex.append_parameter_expression(a + b)
+        samplex.set_passthrough_params([(4, a), (7, 2 * a + b)])
 
-        assert samplex.param_table is table
-        assert table.num_expressions == 2
-        assert samplex.param_table.parameters == samplex.parameters
+        # Mapping form (dict from Parameter to value).
+        idxs, values = samplex.evaluate_passthrough_parameters({a: 1.0, b: 3.0})
+        np.testing.assert_array_equal(idxs, [4, 7])
+        np.testing.assert_allclose(values, [1.0, 5.0])
 
-        np.testing.assert_array_equal(samplex.param_table.evaluate([1.0, 2.0]), [1.0, 3.0])
+        # Sequence form (values in samplex.parameters order — sorted: [a, b]).
+        idxs, values = samplex.evaluate_passthrough_parameters([1.0, 3.0])
+        np.testing.assert_array_equal(idxs, [4, 7])
+        np.testing.assert_allclose(values, [1.0, 5.0])
+
+        # Wrong-length input is rejected via ParameterExpressionTable.evaluate.
+        with pytest.raises(ParameterError):
+            samplex.evaluate_passthrough_parameters([1.0])
 
     def test_add_output(self):
         """Test that we can add an output."""

--- a/test/unit/test_samplex/test_samplex.py
+++ b/test/unit/test_samplex/test_samplex.py
@@ -21,7 +21,7 @@ from qiskit.circuit import Parameter
 
 from samplomatic.exceptions import SamplexConstructionError, SamplexRuntimeError
 from samplomatic.optionals import HAS_PLOTLY
-from samplomatic.samplex import Samplex
+from samplomatic.samplex import ParameterExpressionTable, Samplex
 from samplomatic.samplex.samplex import wait_with_raise
 from samplomatic.tensor_interface import PauliLindbladMapSpecification, TensorSpecification
 from samplomatic.virtual_registers import PauliRegister, U2Register
@@ -83,35 +83,74 @@ class TestBasic:
 
         assert samplex.num_parameters == 3
 
-    def test_evaluate_passthrough_parameters(self):
-        """Test the public introspection method for passthrough parameter values."""
-        from samplomatic.exceptions import ParameterError
-
-        # Empty samplex returns two zero-length arrays of the documented dtypes.
-        empty = Samplex()
-        idxs, values = empty.evaluate_passthrough_parameters({})
-        assert idxs.shape == (0,) and idxs.dtype == np.int64
-        assert values.shape == (0,) and values.dtype == np.float64
-
-        # Wire up two passthrough template parameters: index 4 <- a, index 7 <- 2*a + b.
+    def test_param_table_property(self):
+        """Test that the public ``param_table`` property exposes the underlying table."""
         samplex = Samplex()
+        table = samplex.param_table
+        assert isinstance(table, ParameterExpressionTable)
+        assert table.num_expressions == 0
+
         a = Parameter("a")
         b = Parameter("b")
+        samplex.append_parameter_expression(a)
+        samplex.append_parameter_expression(a + b)
+
+        # The property returns the same instance and reflects mutations.
+        assert samplex.param_table is table
+        assert table.num_expressions == 2
+        assert samplex.param_table.parameters == samplex.parameters
+
+    def test_passthrough_params_property(self):
+        """Test that ``passthrough_params`` reports the (template, expression) index mapping."""
+        # Unset case returns two empty integer arrays.
+        empty = Samplex()
+        template_idxs, expression_idxs = empty.passthrough_params
+        assert template_idxs.shape == (0,) and np.issubdtype(template_idxs.dtype, np.integer)
+        assert expression_idxs.shape == (0,) and np.issubdtype(expression_idxs.dtype, np.integer)
+
+        a = Parameter("a")
+        b = Parameter("b")
+        samplex = Samplex()
+        # Append an unrelated expression first so expression indices != template indices.
+        samplex.append_parameter_expression(a + b)  # expression index 0 (not passthrough)
         samplex.set_passthrough_params([(4, a), (7, 2 * a + b)])
 
-        # Mapping form (dict from Parameter to value).
-        idxs, values = samplex.evaluate_passthrough_parameters({a: 1.0, b: 3.0})
-        np.testing.assert_array_equal(idxs, [4, 7])
-        np.testing.assert_allclose(values, [1.0, 5.0])
+        template_idxs, expression_idxs = samplex.passthrough_params
+        np.testing.assert_array_equal(template_idxs, [4, 7])
+        np.testing.assert_array_equal(expression_idxs, [1, 2])
 
-        # Sequence form (values in samplex.parameters order — sorted: [a, b]).
-        idxs, values = samplex.evaluate_passthrough_parameters([1.0, 3.0])
-        np.testing.assert_array_equal(idxs, [4, 7])
-        np.testing.assert_allclose(values, [1.0, 5.0])
+        # Returned arrays are independent copies — mutating them is harmless.
+        template_idxs[0] = 99
+        expression_idxs[:] = 0
+        again_template_idxs, again_expression_idxs = samplex.passthrough_params
+        np.testing.assert_array_equal(again_template_idxs, [4, 7])
+        np.testing.assert_array_equal(again_expression_idxs, [1, 2])
 
-        # Wrong-length input is rejected via ParameterExpressionTable.evaluate.
-        with pytest.raises(ParameterError):
-            samplex.evaluate_passthrough_parameters([1.0])
+    def test_passthrough_workflow_for_rzz_validation(self):
+        """End-to-end: evaluate only the RZZ-controlling expressions via the new primitives."""
+        from qiskit import QuantumCircuit
+
+        from samplomatic import build
+
+        theta = Parameter("theta")
+        phi = Parameter("phi")
+        circuit = QuantumCircuit(2)
+        circuit.rzz(theta, 0, 1)
+        circuit.rx(phi, 0)
+        template, samplex = build(circuit)
+
+        template_parameters = list(template.parameters)
+        rzz_template_idxs = [
+            template_parameters.index(instr.operation.params[0])
+            for instr in template.data
+            if instr.operation.name == "rzz"
+        ]
+        template_idxs, expression_idxs = samplex.passthrough_params
+        lookup = dict(zip(template_idxs, expression_idxs))
+        rzz_expression_idxs = [lookup[t] for t in rzz_template_idxs]
+
+        angles = samplex.param_table.evaluate({theta: 0.5, phi: 1.2}, indices=rzz_expression_idxs)
+        np.testing.assert_allclose(angles, [0.5])
 
     def test_add_output(self):
         """Test that we can add an output."""


### PR DESCRIPTION
## Summary

This PR exposes three primitives that together let consumers of `build()` evaluate deterministic template parameters (e.g., `RZZ` angles) without invoking `Samplex.sample`:

- `Samplex.param_table` — return the underlying `ParameterExpressionTable`.
- `Samplex.passthrough_params` — a tuple `(template_idxs, expression_idxs)` mapping each passthrough template parameter to its expression-table index.
- `ParameterExpressionTable.evaluate` — gained an optional `indices` argument so callers can evaluate only a chosen subset of the table's expressions.

## Details and comments

An earlier version of this PR just exposed the parameter expression table, but then it was realized this was not sufficient to understand the values of passthrough parameters, which is the real motivation of this PR. As such, the PR was rewritten to expose what is needed.

~I expect that this wasn't done earlier just to minimize the public interface of the library. Probably there were concerns mixed in about who owns the mutation rights, but as always in Python, this can never be perfect. In anycase, this is a useful thing to have access to when interested in the expressions themselves.~
