### PR TITLE
Emit twirl from boundary in left-dressed boxes

### DIFF
--- a/changelog.d/368.changed.md
+++ b/changelog.d/368.changed.md
@@ -1,0 +1,2 @@
+Twirl emissions are now inserted at the easy-hard boundary of boxes with a `Twirl` annotation `"left"` dressing when building.
+Previously, they were inserted after the rest of the content of the box.

--- a/changelog.d/368.changed.md
+++ b/changelog.d/368.changed.md
@@ -1,2 +1,2 @@
 Twirl emissions are now inserted at the easy-hard boundary of boxes with a `Twirl` annotation `"left"` dressing when building.
-Previously, they were inserted after the rest of the content of the box.
+Previously, they were inserted after the content of the box.

--- a/samplomatic/builders/box_builder.py
+++ b/samplomatic/builders/box_builder.py
@@ -240,19 +240,16 @@ class LeftBoxBuilder(BoxBuilder):
                 self.emission.noise_modifier_ref,
                 trace_info=trace_info,
             )
-        if twirl_type := self.emission.twirl_type:
-            if len(self.measured_qubits) != 0:
-                if twirl_type is GroupMode.LOCAL_C1 or (
-                    twirl_type not in GATE_DEPENDENT_TWIRLING_GROUPS
-                    and GROUP_TO_DISTRIBUTION[twirl_type](len(self.emission.qubits)).register_type
-                    != VirtualType.PAULI
-                ):
-                    raise BuildError(
-                        f"Cannot use {twirl_type.value} twirl in a box with measurements."
-                    )
-                self.samplex_state.add_z2_collect(
-                    self.measured_qubits, self.clbit_idxs, trace_info=trace_info
-                )
+        if (twirl_type := self.emission.twirl_type) and len(self.measured_qubits) != 0:
+            if twirl_type is GroupMode.LOCAL_C1 or (
+                twirl_type not in GATE_DEPENDENT_TWIRLING_GROUPS
+                and GROUP_TO_DISTRIBUTION[twirl_type](len(self.emission.qubits)).register_type
+                != VirtualType.PAULI
+            ):
+                raise BuildError(f"Cannot use {twirl_type.value} twirl in a box with measurements.")
+            self.samplex_state.add_z2_collect(
+                self.measured_qubits, self.clbit_idxs, trace_info=trace_info
+            )
 
     @staticmethod
     def yield_from_dag(dag):

--- a/samplomatic/builders/box_builder.py
+++ b/samplomatic/builders/box_builder.py
@@ -161,6 +161,9 @@ class LeftBoxBuilder(BoxBuilder):
                     self.emission.noise_modifier_ref,
                     trace_info=trace_info,
                 )
+            if self.emission.twirl_type:
+                self._emit_twirl(self.emission.twirl_type)
+
             self._mode = InstructionMode.PROPAGATE
             return
 
@@ -238,7 +241,6 @@ class LeftBoxBuilder(BoxBuilder):
                 trace_info=trace_info,
             )
         if twirl_type := self.emission.twirl_type:
-            self._emit_twirl(twirl_type)
             if len(self.measured_qubits) != 0:
                 if twirl_type is GroupMode.LOCAL_C1 or (
                     twirl_type not in GATE_DEPENDENT_TWIRLING_GROUPS

--- a/samplomatic/pre_samplex/pre_samplex.py
+++ b/samplomatic/pre_samplex/pre_samplex.py
@@ -1129,25 +1129,13 @@ class PreSamplex:
         Edge-sorted order
          * places all nodes connected by :class:`~.Direction.LEFT` edges before
            :class:`~.Direction.RIGHT` edges, and
-         * the :class:`~.Direction.LEFT` edges connected to twirl emissions before other emissions,
-            * the twirl emissions sorted according to reverse ``order``,
-            * among the others, :class:`~.PrePropagate` nodes before other non-twirl nodes,
-              each group sorted according to ``order``,
-         * while the :class:`~.Direction.RIGHT` place twirl emissions after other emissions, with
-           :class:`~.PrePropagate` nodes before other non-twirl nodes among the latter, both
-           groups individually sorted according to ``order``.
+         * the :class:`~.Direction.LEFT` edges connected to twirl emissions before other emissions
+           sorted according to reverse ``order``,
+         * while the :class:`~.Direction.RIGHT` place emissions in order.
 
         This order scheme is designed so that it corresponds to circuit-temporal precedence of
         predecessors. For example, a pre-collector will have inbound edges marked both left and
         right. We need to know in which order to multiply them together. This method is that order.
-
-        The :class:`~.PrePropagate`-vs-other-non-twirl tie-breaker is required because
-        :meth:`merge_parallel_pre_propagate_nodes` re-creates the merged node via
-        :func:`~.replace_nodes_with_one_node`, which assigns a fresh (high) graph index. The
-        topological sort then places the merged node late, which would otherwise reverse the
-        relative order of :class:`~.PrePropagate` and emit-style non-twirl predecessors (e.g.
-        :class:`~.PreChangeBasis`), silently breaking the operand order of the downstream
-        :class:`~.CombineRegistersNode`.
 
         Args:
             pre_node_idx: The pre-node to get the predecessors of.
@@ -1162,14 +1150,10 @@ class PreSamplex:
             pred_node = self.graph.get_node_data(pred_idx)
             direction = self.graph.get_edge_data(pred_idx, pre_node_idx).direction
             from_twirl = type(pred_node) is PreEmit
-            # Among non-twirl predecessors, PrePropagate must sort before emit-style nodes
-            # (PreChangeBasis, PreInjectNoise) regardless of topological position.
-            type_priority = 0 if isinstance(pred_node, PrePropagate) else 1
             pred_order = order[pred_idx]
             if direction is Direction.LEFT:
                 pred_order = -pred_order if from_twirl else pred_order
-                from_twirl = not from_twirl
-            edge_sort_keys[pred_idx] = (direction, from_twirl, type_priority, pred_order)
+            edge_sort_keys[pred_idx] = (direction, pred_order)
 
         return sorted(edge_sort_keys.keys(), key=lambda x: edge_sort_keys[x])
 
@@ -1587,7 +1571,7 @@ class PreSamplex:
                 virtual_type = node_predecessor.instantiates()[register_name][1]
             operands[register_name] = (source_idxs, destination_idxs, virtual_type)
 
-        if len(operands) == 1:
+        if len(operands) == 1 and len(source_idxs) == len(subsystems):
             input_register_name, (source_idxs, destination_idxs, input_type) = next(
                 iter(operands.items())
             )

--- a/test/unit/test_builders/test_builders_pre_samplex.py
+++ b/test/unit/test_builders/test_builders_pre_samplex.py
@@ -68,6 +68,7 @@ class TestBoxBuilder:
         builder = self.get_builder(qreg, creg)
         builder.lhs()
         builder.parse(DAGOpNode(Measure(), qreg, [creg[0], creg[2]]))
+        builder.parse(None)
         builder.rhs()
         idxs = QubitIndicesPartition.from_elements(builder.samplex_state.qubit_map.values())
 
@@ -87,6 +88,7 @@ class TestBoxBuilder:
         qreg = QuantumRegister(2)
         builder = self.get_builder(qreg)
         builder.lhs()
+        builder.parse(None)
         builder.rhs()
         idxs = QubitIndicesPartition.from_elements(builder.samplex_state.qubit_map.values())
         assert builder.samplex_state.graph.num_nodes() == 2

--- a/test/unit/test_pre_samplex/test_pre_samplex.py
+++ b/test/unit/test_pre_samplex/test_pre_samplex.py
@@ -357,8 +357,8 @@ class TestHelpersAttributes:
             emit_idx10,
             emit_idx11,
             meas_idx0,
-            prep_idx0,
             emit_idx0,
+            prep_idx0,
         ]
 
         order = {emit_idx0: 50, emit_idx10: 4, emit_idx11: 2}


### PR DESCRIPTION
## Summary

This PR moves the location of twirl emissions from the right-hand side of a left-dressed box to the boundary between easy and hard gates. Adding to allow for support of measure operations as propagators.

## Details and comments

This simplifies the sorted order pretty significantly. 

I also had to make a small change where the choice between `SliceRegisterNode` and `CombineRegistersNode` was made. Previously, when we had a left- then a right-dressed box, as the emits were on the edge of the box opposite the hard content, the emissions from both would be combined to always match the number of subsystems for any hard gates. This is not the case anymore for examples like the following:

```
with circuit.box([Twirl()]):
     circuit.cx(0, 1)

with circuit.box([Twirl()]):
     circuit.h(0)

with circuit.box([Twirl(dressing="right")]):
     circuit.cx(0, 1)
```
Here, the emission on qubit 1 from the right dressed box would error when encountering the CX from the first box as it selects a `SliceRegisterNode` that is trying to write a single register to two registers. The change in this PR looks for these cases and instead uses a `CombineRegisterNode` that starts with an identity on the correct number of subsystems and multiplies the virtual register on a smaller number of subsystems into it. 