### PR TITLE
Allow gate dependent twirling of different entanglers in the same box

### DIFF
--- a/changelog.d/370.changed.md
+++ b/changelog.d/370.changed.md
@@ -1,1 +1,0 @@
-Removed the restriction of `Group.local_c1` of having a single entangler type in a given box.

--- a/changelog.d/370.changed.md
+++ b/changelog.d/370.changed.md
@@ -1,0 +1,1 @@
+Removed the restriction of `Group.local_c1` of having a single entangler type in a given box.

--- a/changelog.d/370.fixed.md
+++ b/changelog.d/370.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue when using `GroupMode.local_pauli` twirling where the fallback for Clifford gates to the Pauli group would not trigger when a fractional gate was also present.

--- a/changelog.d/370.improved.md
+++ b/changelog.d/370.improved.md
@@ -1,0 +1,1 @@
+Removed the restriction of having a single entangler type when using `Group.local_c1`.

--- a/samplomatic/builders/box_builder.py
+++ b/samplomatic/builders/box_builder.py
@@ -100,13 +100,14 @@ class BoxBuilder(Builder[TemplateState, PreSamplex, ParsableType]):
     def _emit_twirl(self, twirl_type: GroupMode):
         trace_info = self._trace_info
         if twirl_type in GATE_DEPENDENT_TWIRLING_GROUPS:
-            if len(self.emission.gate_dependent_twirl_qubits):
-                self.samplex_state.add_emit_twirl(
-                    self.emission.gate_dependent_twirl_qubits,
-                    twirl_type,
-                    self.emission.twirl_gate,
-                    trace_info=trace_info,
-                )
+            if len(self.emission.gate_dependent_twirls):
+                for gate_name, qubits in self.emission.gate_dependent_twirls.items():
+                    self.samplex_state.add_emit_twirl(
+                        qubits,
+                        twirl_type,
+                        gate_name,
+                        trace_info=trace_info,
+                    )
             if len(self.emission.fallback_twirl_qubits):
                 self.samplex_state.add_emit_twirl(
                     self.emission.fallback_twirl_qubits,

--- a/samplomatic/builders/get_builder.py
+++ b/samplomatic/builders/get_builder.py
@@ -43,7 +43,7 @@ def _classify_gate_dependent_twirl(body, emission: EmissionSpec) -> None:
     """Classify qubits in a gate-dependent twirl box into entangling and fallback qubits.
 
     Inspects the box body DAG for two-qubit gates and splits qubits accordingly.
-    Mutates ``emission`` in place to set ``gate_dependent_twirl_qubits``, ``fallback_twirl_qubits``,
+    Mutates ``emission`` in place to set ``gate_dependent_twirls``, ``fallback_twirl_qubits``,
     and ``twirl_gate``. If no two-qubit gates are found, sets ``twirl_type`` to PAULI.
 
     Raises:
@@ -53,7 +53,7 @@ def _classify_gate_dependent_twirl(body, emission: EmissionSpec) -> None:
     """
     dag = circuit_to_dag(body)
     seen_pairs = QubitPartition(2, [])
-    gate_names: set[str] = set()
+    gate_pairs: dict[str, QubitPartition] = {}
 
     for node in dag.topological_op_nodes():
         if node.is_standard_gate() and node.op.num_qubits == 2:
@@ -63,38 +63,33 @@ def _classify_gate_dependent_twirl(body, emission: EmissionSpec) -> None:
                     f"Cannot use gate-dependent twirling with duplicate 2Q gates on qubits {pair}."
                 )
             # QubitPartition.add rejects partial overlaps automatically
+            gate_pairs.setdefault(node.op.name, QubitPartition(2, [])).add(pair)
             seen_pairs.add(pair)
-            gate_names.add(node.op.name)
 
     if emission.twirl_type == GroupMode.LOCAL_PAULI:
-        gate_names = gate_names.intersection(SUPPORTED_2Q_FRACTIONAL_GATES)
+        gate_pairs = {k: v for k, v in gate_pairs.items() if k in SUPPORTED_2Q_FRACTIONAL_GATES}
 
-    if not gate_names:
+    if not gate_pairs:
         emission.twirl_type = GroupMode.PAULI
         return
 
-    if len(gate_names) > 1:
-        raise BuildError(
-            f"Cannot use {emission.twirl_type} twirling with multiple 2Q gate types: {gate_names}."
-        )
-
-    (gate,) = gate_names
-    emission.twirl_gate = gate
-
-    # Gate-dependent qubits: flatten pairs preserving operand order
-    gate_dependent_qubit_list = []
+    gate_dependent_twirls = {}
     seen_qubits = set()
-    for pair in seen_pairs:
-        for q in pair:
-            if q not in seen_qubits:
-                seen_qubits.add(q)
-                gate_dependent_qubit_list.append((q,))
+    for gate, pairs in gate_pairs.items():
+        # Gate-dependent qubits: flatten pairs preserving operand order
+        gate_dependent_qubit_list = []
+        for pair in pairs:
+            for q in pair:
+                if q not in seen_qubits:
+                    seen_qubits.add(q)
+                    gate_dependent_qubit_list.append((q,))
+        gate_dependent_twirls[gate] = QubitPartition(1, gate_dependent_qubit_list)
 
-    emission.gate_dependent_twirl_qubits = QubitPartition(1, gate_dependent_qubit_list)
+    emission.gate_dependent_twirls = gate_dependent_twirls
 
     # Pauli qubits: remainder
     all_qubits = {q for subsys in emission.qubits for q in subsys}
-    fallback_only = all_qubits - emission.gate_dependent_twirl_qubits.all_elements
+    fallback_only = all_qubits - seen_qubits
     emission.fallback_twirl_qubits = QubitPartition(1, [(q,) for q in fallback_only])
 
 

--- a/samplomatic/builders/specs.py
+++ b/samplomatic/builders/specs.py
@@ -64,14 +64,11 @@ class EmissionSpec:
     twirl_type: GroupMode | None = None
     """What type and distribution of virtual gates to emit for twirling."""
 
-    gate_dependent_twirl_qubits: QubitPartition | None = None
+    gate_dependent_twirls: dict[str, QubitPartition] | None = None
     """The qubits with entanglers when using gate-dependent twirling."""
 
     fallback_twirl_qubits: QubitPartition | None = None
     """The qubits without entanglers when using gate-dependent twirling."""
-
-    twirl_gate: str | None = None
-    """The entangler to twirl for gate-dependent twirling."""
 
     basis_change: FrameChangeMode | None = None
     """What type of basis change to use."""

--- a/samplomatic/builders/specs.py
+++ b/samplomatic/builders/specs.py
@@ -65,7 +65,7 @@ class EmissionSpec:
     """What type and distribution of virtual gates to emit for twirling."""
 
     gate_dependent_twirls: dict[str, QubitPartition] | None = None
-    """The qubits with entanglers when using gate-dependent twirling."""
+    """A map from gate names that require gate-dependent twirling to subsystems to twirl."""
 
     fallback_twirl_qubits: QubitPartition | None = None
     """The qubits without entanglers when using gate-dependent twirling."""

--- a/test/unit/test_builders/test_gate_dependent_twirl_building.py
+++ b/test/unit/test_builders/test_gate_dependent_twirl_building.py
@@ -10,19 +10,20 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Test error cases for local_c1 twirling."""
+"""Test gate-dependent twirl buidling."""
 
 import pytest
-from qiskit.circuit import QuantumCircuit
+from qiskit.circuit import Parameter, QuantumCircuit
 
 from samplomatic import Twirl
 from samplomatic.builders import pre_build
 from samplomatic.exceptions import BuildError
+from samplomatic.pre_samplex import PreEmit
 
 
-class TestLocalC1BuildErrors:
-    def test_multiple_2q_gate_types_left(self):
-        """Error when a left-dressed local_c1 box has multiple 2Q gate types."""
+class TestGateDependetTwirling:
+    def test_multiple_2q_gates_local_c1(self):
+        """Test left-dressed local_c1 box has multiple 2Q gate emissions."""
         circuit = QuantumCircuit(4)
         with circuit.box([Twirl(group="local_c1", dressing="left")]):
             circuit.cx(0, 1)
@@ -31,21 +32,28 @@ class TestLocalC1BuildErrors:
         with circuit.box([Twirl(dressing="right")]):
             circuit.noop(0, 1, 2, 3)
 
-        with pytest.raises(BuildError, match="multiple 2Q gate types"):
-            pre_build(circuit)
+        _, pre_samplex = pre_build(circuit)
+        pre_emits = [node for node in pre_samplex.graph.nodes() if isinstance(node, PreEmit)]
 
-    def test_multiple_2q_gate_types_right(self):
-        """Error when a right-dressed local_c1 box has multiple 2Q gate types."""
+        assert len(pre_emits) == 3
+        assert any(n.twirl_gate == "cz" and n.register_type == "local_c1" for n in pre_emits)
+        assert any(n.twirl_gate == "cx" and n.register_type == "local_c1" for n in pre_emits)
+        assert any(n.twirl_gate is None and n.register_type == "pauli" for n in pre_emits)
+
+    def test_multiple_2q_gate_local_pauli(self):
+        """Test left-dressed local_pauli box has multiple 2Q gate emissions."""
         circuit = QuantumCircuit(4)
-        with circuit.box([Twirl(group="local_c1", dressing="left")]):
-            circuit.noop(0, 1, 2, 3)
-
-        with circuit.box([Twirl(group="local_c1", dressing="right")]):
-            circuit.cx(0, 1)
+        with circuit.box([Twirl(group="local_pauli", dressing="left")]):
+            circuit.rzz(Parameter("a"), 0, 1)
             circuit.cz(2, 3)
+            circuit.measure_all()
 
-        with pytest.raises(BuildError, match="multiple 2Q gate types"):
-            pre_build(circuit)
+        _, pre_samplex = pre_build(circuit)
+        pre_emits = [node for node in pre_samplex.graph.nodes() if isinstance(node, PreEmit)]
+
+        assert len(pre_emits) == 2
+        assert any(n.twirl_gate == "rzz" and n.register_type == "local_pauli" for n in pre_emits)
+        assert any(n.twirl_gate is None and n.register_type == "pauli" for n in pre_emits)
 
     def test_overlapping_2q_gates_same_pair(self):
         """Error when a local_c1 box has duplicate 2Q gates on the same qubits."""


### PR DESCRIPTION
## Summary

## Details and comments

Also fixes an issue where fallback in the `local_pauli` group mode would be set improperly if both an RZZ and a Clifford entangler are present.