### PR TITLE
Add warning of upcoming change of default for inject noise site

### DIFF
--- a/changelog.d/372.changed.md
+++ b/changelog.d/372.changed.md
@@ -1,1 +1,1 @@
-The default `inject_noise_site` for `generate_boxing_pass_manager` and the `AddInjectNoise` pass was changed from `"before"` to `"after"`.
+The default argument of `inject_noise_site` for for the `AddInjectNoise` pass was changed from `'before'` to `'after'`.

--- a/changelog.d/372.changed.md
+++ b/changelog.d/372.changed.md
@@ -1,1 +1,0 @@
-The default argument of `inject_noise_site` for for the `AddInjectNoise` pass was changed from `'before'` to `'after'`.

--- a/changelog.d/372.changed.md
+++ b/changelog.d/372.changed.md
@@ -1,0 +1,1 @@
+The default `inject_noise_site` for `generate_boxing_pass_manager` and the `AddInjectNoise` pass was changed from `"before"` to `"after"`.

--- a/changelog.d/372.deprecated.md
+++ b/changelog.d/372.deprecated.md
@@ -1,1 +1,1 @@
-The default value for `inject_noise_site` for the `generate_boxing_pass_manager` has been updated from `'before'` to `None`, which will results in a deprecation warning but sets the value to `'before'`. In a future release, it will be updated to `'after'`.
+The default value for the inject noise site for the `generate_boxing_pass_manager`, `AddInjectNoise`, and `InjectNoise` has been updated from `'before'` to `None`, which will results in a future warning and sets the value to `'before'`. In a future release, the default will be updated to `'after'`.

--- a/changelog.d/372.deprecated.md
+++ b/changelog.d/372.deprecated.md
@@ -1,0 +1,1 @@
+The default value for `inject_noise_site` for the `generate_boxing_pass_manager` has been updated from `'before'` to `None`, which will results in a deprecation warning but sets the value to `'before'`. In a future release, it will be updated to `'after'`.

--- a/samplomatic/annotations/inject_noise.py
+++ b/samplomatic/annotations/inject_noise.py
@@ -12,6 +12,7 @@
 
 """InjectNoise"""
 
+import warnings
 from enum import Enum
 from typing import Literal, TypeAlias
 
@@ -53,10 +54,19 @@ class InjectNoise(Annotation):
         self,
         ref: StrRef,
         modifier_ref: StrRef = "",
-        site: InjectionSiteLiteral = "before",
+        site: InjectionSiteLiteral | None = None,
     ):
         self.ref = ref
         self.modifier_ref = modifier_ref
+
+        if site is None:
+            warnings.warn(
+                "The default of the 'inject_noise_site' argument will be changed from "
+                "`'before'` to after in version 0.21.0.",
+                FutureWarning,
+                stacklevel=1,
+            )
+            site = "before"
         self.site = InjectionSite(site)
 
     def __eq__(self, other):

--- a/samplomatic/annotations/inject_noise.py
+++ b/samplomatic/annotations/inject_noise.py
@@ -62,7 +62,7 @@ class InjectNoise(Annotation):
         if site is None:
             warnings.warn(
                 "The default of the 'inject_noise_site' argument will be changed from "
-                "`'before'` to after in version 0.21.0.",
+                "'before' to 'after' no sooner than version 0.21.0.",
                 FutureWarning,
                 stacklevel=1,
             )

--- a/samplomatic/transpiler/generate_boxing_pass_manager.py
+++ b/samplomatic/transpiler/generate_boxing_pass_manager.py
@@ -250,7 +250,7 @@ def generate_boxing_pass_manager(
     if inject_noise_site is None:
         warnings.warn(
             "The default of the 'inject_noise_site' argument will be changed from "
-            "`'before'` to after in version 0.21.0.",
+            "'before' to 'after' no sooner than version 0.21.0.",
             FutureWarning,
             stacklevel=1,
         )

--- a/samplomatic/transpiler/generate_boxing_pass_manager.py
+++ b/samplomatic/transpiler/generate_boxing_pass_manager.py
@@ -250,8 +250,8 @@ def generate_boxing_pass_manager(
     if inject_noise_site is None:
         warnings.warn(
             "The default of the 'inject_noise_site' argument will be changed from "
-            "`'before'` to `"after"` no sooner than version 0.21.0.",
-            DeprecationWarning,
+            "`'before'` to after in version 0.21.0.",
+            FutureWarning,
             stacklevel=1,
         )
         inject_noise_site = "before"

--- a/samplomatic/transpiler/generate_boxing_pass_manager.py
+++ b/samplomatic/transpiler/generate_boxing_pass_manager.py
@@ -12,6 +12,7 @@
 
 """generate_boxing_pass_manager"""
 
+import warnings
 from typing import Literal
 
 from qiskit.transpiler import PassManager
@@ -63,7 +64,7 @@ def generate_boxing_pass_manager(
     inject_noise_strategy: Literal[
         "no_modification", "uniform_modification", "individual_modification"
     ] = "no_modification",
-    inject_noise_site: Literal["before", "after"] = "after",
+    inject_noise_site: Literal["before", "after", None] = None,
     remove_barriers: Literal[
         "immediately", "finally", "after_stratification", "never", True, False
     ] = "after_stratification",
@@ -245,6 +246,15 @@ def generate_boxing_pass_manager(
         remove_barriers = "immediately"
     elif remove_barriers is False:
         remove_barriers = "never"
+
+    if inject_noise_site is None:
+        warnings.warn(
+            "The default of the 'inject_noise_site' argument will be changed from "
+            "`'before'` to after in version 0.21.0.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+        inject_noise_site = "before"
 
     passes = []
     if remove_barriers == "immediately":

--- a/samplomatic/transpiler/generate_boxing_pass_manager.py
+++ b/samplomatic/transpiler/generate_boxing_pass_manager.py
@@ -250,7 +250,7 @@ def generate_boxing_pass_manager(
     if inject_noise_site is None:
         warnings.warn(
             "The default of the 'inject_noise_site' argument will be changed from "
-            "`'before'` to after in version 0.21.0.",
+            "`'before'` to `"after"` no sooner than version 0.21.0.",
             DeprecationWarning,
             stacklevel=1,
         )

--- a/samplomatic/transpiler/generate_boxing_pass_manager.py
+++ b/samplomatic/transpiler/generate_boxing_pass_manager.py
@@ -63,7 +63,7 @@ def generate_boxing_pass_manager(
     inject_noise_strategy: Literal[
         "no_modification", "uniform_modification", "individual_modification"
     ] = "no_modification",
-    inject_noise_site: Literal["before", "after"] = "before",
+    inject_noise_site: Literal["before", "after"] = "after",
     remove_barriers: Literal[
         "immediately", "finally", "after_stratification", "never", True, False
     ] = "after_stratification",

--- a/samplomatic/transpiler/passes/add_inject_noise.py
+++ b/samplomatic/transpiler/passes/add_inject_noise.py
@@ -13,6 +13,7 @@
 """AddInjectNoise"""
 
 import itertools
+import warnings
 from collections.abc import Callable
 from typing import Literal
 
@@ -69,7 +70,7 @@ class AddInjectNoise(TransformationPass):
         strategy: Literal[
             "no_modification", "uniform_modification", "individual_modification"
         ] = "no_modification",
-        site: Literal["before", "after"] = "after",
+        site: Literal["before", "after", None] = None,
         overwrite: bool = False,
         prefix_ref: str = "r",
         prefix_modifier_ref: str = "m",
@@ -77,11 +78,20 @@ class AddInjectNoise(TransformationPass):
     ):
         super().__init__()
         self.strategy = strategy
-        self.site = site
         self.overwrite = overwrite
         self.prefix_ref = prefix_ref
         self.prefix_modifier_ref = prefix_modifier_ref
         self.targets = targets
+
+        if site is None:
+            warnings.warn(
+                "The default of the 'inject_noise_site' argument will be changed from "
+                "`'before'` to after in version 0.21.0.",
+                FutureWarning,
+                stacklevel=1,
+            )
+            site = "before"
+        self.site = site
 
     def _get_ref(self, box_key: BoxKey) -> str:
         pair = (box_key, self.site)

--- a/samplomatic/transpiler/passes/add_inject_noise.py
+++ b/samplomatic/transpiler/passes/add_inject_noise.py
@@ -69,7 +69,7 @@ class AddInjectNoise(TransformationPass):
         strategy: Literal[
             "no_modification", "uniform_modification", "individual_modification"
         ] = "no_modification",
-        site: Literal["before", "after"] = "before",
+        site: Literal["before", "after"] = "after",
         overwrite: bool = False,
         prefix_ref: str = "r",
         prefix_modifier_ref: str = "m",

--- a/samplomatic/transpiler/passes/add_inject_noise.py
+++ b/samplomatic/transpiler/passes/add_inject_noise.py
@@ -86,7 +86,7 @@ class AddInjectNoise(TransformationPass):
         if site is None:
             warnings.warn(
                 "The default of the 'inject_noise_site' argument will be changed from "
-                "`'before'` to after in version 0.21.0.",
+                "'before' to 'after' no sooner than version 0.21.0.",
                 FutureWarning,
                 stacklevel=1,
             )

--- a/test/unit/test_annotations/test_inject_noise.py
+++ b/test/unit/test_annotations/test_inject_noise.py
@@ -1,6 +1,6 @@
 # This code is a Qiskit project.
 #
-# (C) Copyright IBM 2025.
+# (C) Copyright IBM 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -9,8 +9,15 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+import pytest
 
 from samplomatic.annotations import InjectionSite, InjectNoise
+
+
+def test_site_future_warning():
+    """Test default value of the ``site`` argument raises a futures warning."""
+    with pytest.warns(FutureWarning):
+        InjectNoise("my_ref")
 
 
 def test_construction():

--- a/test/unit/test_transpiler/test_generate_boxing_pass_manager.py
+++ b/test/unit/test_transpiler/test_generate_boxing_pass_manager.py
@@ -46,6 +46,21 @@ def test_remove_barriers_deprecation():
     assert pm_false.run(circuit) == pm_never.run(circuit)
 
 
+def test_inject_noise_site_deprecation():
+    """Test deprecated default values of the ``inject_noise_site`` option."""
+    circuit = QuantumCircuit(2)
+    circuit.cx(0, 1)
+    circuit.cx(0, 1)
+
+    with pytest.warns(DeprecationWarning):
+        pm_none = generate_boxing_pass_manager()
+
+    pm_before = generate_boxing_pass_manager(
+        inject_noise_strategy="uniform_modification", inject_noise_site="before"
+    )
+    assert pm_none.run(circuit) == pm_before.run(circuit)
+
+
 @pytest.mark.parametrize(
     "decomposition,measure_annotations", [("rzrx", "all"), ("rzsx", "change_basis")]
 )

--- a/test/unit/test_transpiler/test_generate_boxing_pass_manager.py
+++ b/test/unit/test_transpiler/test_generate_boxing_pass_manager.py
@@ -52,7 +52,7 @@ def test_inject_noise_site_deprecation():
     circuit.cx(0, 1)
     circuit.cx(0, 1)
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         pm_none = generate_boxing_pass_manager()
 
     pm_before = generate_boxing_pass_manager(

--- a/test/unit/test_transpiler/test_passes/test_add_inject_noise.py
+++ b/test/unit/test_transpiler/test_passes/test_add_inject_noise.py
@@ -23,6 +23,12 @@ from samplomatic.transpiler.passes import AddInjectNoise
 from samplomatic.utils import get_annotation
 
 
+def test_site_future_warning():
+    """Test default value of the ``site`` argument raises a futures warning."""
+    with pytest.warns(FutureWarning):
+        AddInjectNoise()
+
+
 def test_no_modification_strategy():
     """Test `AddInjectNoise` with the ``"no_modification"`` strategy."""
     circuit = QuantumCircuit(2)


### PR DESCRIPTION
## Summary

Warns that the defaults of the boxing pass manager, AddInjectNoise pass, and InjectNoise annotation will change the default to use "after" in an upcoming release.

## Details and comments
