### PR TITLE
Always block leftward propagation through boxed measure

### DIFF
--- a/changelog.d/373.fixed.md
+++ b/changelog.d/373.fixed.md
@@ -1,0 +1,1 @@
+Fixed a bug where untwirled measurements in annotated boxes did not block leftwards virtual gate propagation.

--- a/samplomatic/pre_samplex/pre_samplex.py
+++ b/samplomatic/pre_samplex/pre_samplex.py
@@ -642,11 +642,11 @@ class PreSamplex:
         )
         found_predecessors = list(self.find_then_remove_danglers(match, subsystems))
 
-        if not found_predecessors:
-            return None
-
         # cannot propagate left through a measure
         list(self.find_then_remove_danglers(DanglerMatch(direction=Direction.LEFT), subsystems))
+
+        if not found_predecessors:
+            return None
 
         node = PreMeasure(subsystems, [creg_name], [creg_offset], trace_info=trace_info)
         node_idx = self.graph.add_node(node)

--- a/samplomatic/pre_samplex/pre_samplex.py
+++ b/samplomatic/pre_samplex/pre_samplex.py
@@ -597,10 +597,7 @@ class PreSamplex:
         return node_idx
 
     def add_measure_propagate(
-        self,
-        instr: DAGOpNode,
-        clbit_idx: ClbitIndex,
-        trace_info: TraceInfo | None = None,
+        self, instr: DAGOpNode, clbit_idx: ClbitIndex, trace_info: TraceInfo | None = None
     ) -> int | None:
         """Add a node that propagates virtual Paulis through a measurement.
 
@@ -611,8 +608,6 @@ class PreSamplex:
         Args:
             instr: The measurement instruction.
             clbit_idx: The global classical bit index.
-            creg_name: The classical register name.
-            creg_offset: The index within the classical register.
             trace_info: Optional debug trace info to attach to the node.
 
         Returns:

--- a/test/unit/test_pre_samplex/test_pre_samplex.py
+++ b/test/unit/test_pre_samplex/test_pre_samplex.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 import pytest
-from qiskit.circuit import Parameter, QuantumCircuit, QuantumRegister
+from qiskit.circuit import ClassicalRegister, Parameter, QuantumCircuit, QuantumRegister
 from qiskit.circuit.library import CXGate, Measure, RXGate, RZGate
 from qiskit.converters import circuit_to_dag
 from qiskit.dagcircuit import DAGOpNode
@@ -205,30 +205,35 @@ class TestBuildPreSamplex:
         with pytest.raises(SamplexBuildError, match="overlaps partially with .* collectors.* left"):
             pre_samplex.add_propagate(DAGOpNode(CXGate(), qreg), InstructionMode.NONE, [])
 
-    def test_propagate_through_measurement_is_noop(self):
-        """Test that add_propagate on a measurement is a no-op."""
+    def test_add_measure_propagate(self):
+        """Test add_measure_propagate."""
+        qreg = QuantumRegister(2)
+        creg = ClassicalRegister(1)
+
+        pre_samplex = PreSamplex(qubit_map={q: idx for idx, q in enumerate(qreg)}, cregs=[creg])
+        pre_samplex.add_collect(QubitPartition.from_elements([qreg[0], qreg[1]]), RzSxSynth(), [])
+        pre_samplex.add_emit_twirl(QubitPartition.from_elements([qreg[0], qreg[1]]), PauliRegister)
+        pre_samplex.add_measure_propagate(DAGOpNode(Measure(), [qreg[0]]), 0, [])
+        pre_samplex.add_collect(QubitPartition.from_elements([qreg[0], qreg[1]]), RzSxSynth(), [])
+
+        # edges: collect0 to emit, emit to measure, emit to collect1, measure to collect1
+        assert len(pre_samplex.graph.edges()) == 4
+        assert len(pre_samplex.graph.nodes()) == 4
+
+    def test_add_measure_propagate_removes_left_danglers(self):
+        """Test that add_measure_propagate removes left danglers."""
         qreg = QuantumRegister(1)
+        creg = ClassicalRegister(1)
 
-        pre_samplex = PreSamplex(qubit_map={qreg[0]: 0})
+        left_match = DanglerMatch(direction=Direction.LEFT)
+        subsystems = QubitIndicesPartition.from_elements([0])
+
+        pre_samplex = PreSamplex(qubit_map={qreg[0]: 0}, cregs=[creg])
         pre_samplex.add_collect(QubitPartition.from_elements(qreg), RzSxSynth(), [])
-        pre_samplex.add_emit_twirl(QubitPartition.from_elements(qreg), PauliRegister)
-        pre_samplex.add_propagate(DAGOpNode(Measure(), qreg), InstructionMode.NONE, [])
+        assert len(list(pre_samplex.find_danglers(left_match, subsystems))) == 1
 
-        assert len(pre_samplex.graph.nodes()) == 2
-        assert len(pre_samplex.graph.edges()) == 1
-
-    def test_add_propagate_measurement(self):
-        """Test that add_propagate on a measurement works when no virtual gate is met."""
-        qreg = QuantumRegister(1)
-
-        pre_samplex = PreSamplex(qubit_map={qreg[0]: 0})
-        pre_samplex.add_collect(QubitPartition.from_elements(qreg), RzSxSynth(), [])
-        pre_samplex.add_propagate(DAGOpNode(Measure(), qreg), InstructionMode.NONE, [])
-        pre_samplex.add_collect(QubitPartition.from_elements(qreg), RzSxSynth(), [])
-        pre_samplex.add_emit_twirl(QubitPartition.from_elements(qreg), PauliRegister)
-
-        assert len(pre_samplex.graph.edges()) == 1
-        assert len(pre_samplex.graph.nodes()) == 3
+        pre_samplex.add_measure_propagate(DAGOpNode(Measure(), qreg), 0, [])
+        assert len(list(pre_samplex.find_danglers(left_match, subsystems))) == 0
 
     @pytest.mark.parametrize("gate", [RXGate, RZGate])
     def test_prepropagate_validation(self, gate):


### PR DESCRIPTION
## Summary

Closes #361.

## Details and comments

This issue predates the measure twirl refactor but the new approach makes the fix much simpler.