### PR TITLE
Only raise `inject_noise_site` deprecation in the PM when injecting noise

### DIFF
--- a/samplomatic/transpiler/generate_boxing_pass_manager.py
+++ b/samplomatic/transpiler/generate_boxing_pass_manager.py
@@ -247,7 +247,7 @@ def generate_boxing_pass_manager(
     elif remove_barriers is False:
         remove_barriers = "never"
 
-    if inject_noise_site is None:
+    if inject_noise_targets != "none" and inject_noise_site is None:
         warnings.warn(
             "The default of the 'inject_noise_site' argument will be changed from "
             "'before' to 'after' no sooner than version 0.21.0.",


### PR DESCRIPTION
## Summary

This PR makes the `generate_boxing_pass_manager` deprecation warning a bit quieter by only displaying it when relevant, that is, when noise injection is actually being used.

## Details and comments
