### PR TITLE
Fix edge rendering in plot_graph()

### DIFF
--- a/changelog.d/378.fixed.md
+++ b/changelog.d/378.fixed.md
@@ -1,0 +1,1 @@
+Fixed `samplomatic.visualization.plot_graph()` to draw straight lines between nodes when the edge data is missing. Prior to this fix, it used a spline that sometimes ended up curved in strange ways.

--- a/samplomatic/visualization/graphviz_layout.py
+++ b/samplomatic/visualization/graphviz_layout.py
@@ -34,7 +34,7 @@ def graphviz_layout(
     layout: Literal["dot", "neato"],
     rankdir: Literal["LR", "RL", "BT"] = "LR",
     spline: Literal["spline", "curved", "line", "polyline", "ortho"] = "spline",
-) -> tuple[NodeLayout, EdgeLayout]:
+) -> NodeLayout | tuple[NodeLayout, EdgeLayout]:
     """Compute layout coordinates using pygraphviz.
 
     Args:
@@ -93,7 +93,7 @@ def graphviz_layout(
 
             edge_layout[edge_idx] = render_bezier_spline(coords)
 
-    return node_layout if spline == "line" else node_layout, edge_layout
+    return node_layout if spline == "line" else (node_layout, edge_layout)
 
 
 def render_bezier_spline(

--- a/samplomatic/visualization/graphviz_layout.py
+++ b/samplomatic/visualization/graphviz_layout.py
@@ -93,7 +93,7 @@ def graphviz_layout(
 
             edge_layout[edge_idx] = render_bezier_spline(coords)
 
-    return node_layout, edge_layout
+    return node_layout if spline == "line" else node_layout, edge_layout
 
 
 def render_bezier_spline(

--- a/samplomatic/visualization/plot_graph.py
+++ b/samplomatic/visualization/plot_graph.py
@@ -1,6 +1,6 @@
 # This code is a Qiskit project.
 #
-# (C) Copyright IBM 2025.
+# (C) Copyright IBM 2025-2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -135,6 +135,7 @@ def plot_graph(
         nodes = subgraph.nodes()
 
         layout = layout_method(subgraph, ranker)
+        line_shape = "spline" if isinstance(layout, tuple) else "linear"
         node_layout, raw_edge_coords = _add_edge_layout(subgraph, layout)
 
         # Coordinates of nodes, shape (num_nodes, 2), last axis for (x, y)
@@ -180,7 +181,7 @@ def plot_graph(
                 go.Scatter(
                     x=edge_coords[:, 0],
                     y=edge_coords[:, 1],
-                    line=dict(color=COLOR_EDGES, shape="spline", smoothing=1.0),
+                    line=dict(color=COLOR_EDGES, shape=line_shape, smoothing=1.0),
                     hoverinfo="text",
                     hovertext=edge_hovertexts,
                     mode="lines+markers",

--- a/test/integration/test_inject_noise_samples.py
+++ b/test/integration/test_inject_noise_samples.py
@@ -160,7 +160,7 @@ def test_sampling(circuit, expected, pauli_lindblad_maps, save_plot):
 
     template_state, samplex_state = pre_build(circuit)
     template = template_state.finalize()
-    save_plot(lambda: template.template.draw("mpl"), "Template Circuit", delayed=True)
+    save_plot(lambda: template.draw("mpl"), "Template Circuit", delayed=True)
     save_plot(lambda: samplex_state.draw(), "Unfinalized Pre-Samplex", delayed=True)
 
     samplex = samplex_state.finalize()

--- a/test/integration/test_parametric_twirling_samples.py
+++ b/test/integration/test_parametric_twirling_samples.py
@@ -153,7 +153,7 @@ def test_sampling(rng, circuit, save_plot):
 
     template_state, pre_samplex = pre_build(circuit)
     template = template_state.finalize()
-    save_plot(lambda: template.template.draw("mpl"), "Template Circuit", delayed=True)
+    save_plot(lambda: template.draw("mpl"), "Template Circuit", delayed=True)
     save_plot(lambda: pre_samplex.draw(), "Unfinalized Pre-Samplex", delayed=True)
 
     samplex = pre_samplex.finalize()


### PR DESCRIPTION
## Summary

This PR fixes the `plot_graph()` function so that when a GraphLayout has no edge data, it just draws straight lines instead of trying to do a weird spline.
This predominantly fixes the `graphvis_line` mode.

## Details and comments

It also fixes some long-standing typos when the `--save-plots` argument is set in pytest---I guess this isn't used very often, but I used it here.

Before this PR with `graphvis_line`:
<img width="1823" height="350" alt="image" src="https://github.com/user-attachments/assets/83907769-060c-4cdd-a5c4-eaa18d3d33e2" />


After this PR with `graphvis_line`:
<img width="1828" height="351" alt="image" src="https://github.com/user-attachments/assets/f2ee0d56-60f7-4899-9e8a-e15941e94347" />

