### PR TITLE
Clean up 0-bit instruction behaviour in generate_boxing_pass_manager()

### DIFF
--- a/changelog.d/377.fixed.md
+++ b/changelog.d/377.fixed.md
@@ -1,0 +1,7 @@
+Fixed a crash in `generate_boxing_pass_manager` when the input circuit contained inline
+`GlobalPhaseGate` (or other zero-bit) instructions. The `GroupGatesIntoBoxes` and
+`GroupMeasIntoBoxes` passes now treat zero-qubit standard gates as pass-through and no
+longer fail on operations with empty `qargs` and `cargs` (such as a zero-width barrier).
+Note that, independently, `build()` does not and has never preserved
+`QuantumCircuit.global_phase` in the template circuit; this expected behavior is now
+documented in the `build()` docstring.

--- a/samplomatic/builders/build.py
+++ b/samplomatic/builders/build.py
@@ -96,6 +96,11 @@ def pre_build(circuit: QuantumCircuit, debug: bool = False) -> tuple[TemplateSta
 def build(circuit: QuantumCircuit, debug: bool = False) -> tuple[QuantumCircuit, Samplex]:
     """Build a circuit template and samplex for the given boxed-up circuit.
 
+    .. note::
+
+        The template circuit does not preserve the ``global_phase`` of the input circuit, it is
+        always set to zero.
+
     Args:
         circuit: The circuit to build.
         debug: Whether to populate samplex nodes with information that traces them back to the boxes

--- a/samplomatic/transpiler/passes/group_gates_into_boxes.py
+++ b/samplomatic/transpiler/passes/group_gates_into_boxes.py
@@ -73,8 +73,9 @@ class GroupGatesIntoBoxes(TransformationPass):
         for node in dag.topological_op_nodes():
             validate_op_is_supported(node)
 
-            # The index of the earliest group able to collect ops on all the bits in this node
-            group_idx: int = max(group_indices[bit] for bit in node.qargs + node.cargs)
+            # The index of the earliest group able to collect ops on all the bits in this node.
+            # default=0 protects against ops with no qargs and no cargs (e.g. a zero-width barrier).
+            group_idx: int = max((group_indices[bit] for bit in node.qargs + node.cargs), default=0)
 
             if (name := node.op.name) in ["barrier", "box"]:
                 # Flush the single-qubit gate nodes and place them in a group
@@ -86,8 +87,8 @@ class GroupGatesIntoBoxes(TransformationPass):
                 clbit = node.cargs[0]
 
                 group_indices[qubit] = group_indices[clbit] = group_idx
-            elif node.is_standard_gate() and node.op.num_qubits == 1:
-                # Leave single-qubit gates alone
+            elif node.is_standard_gate() and node.op.num_qubits <= 1:
+                # Leave zero- and single-qubit gates alone (global phase gate is 0 qubits)
                 continue
             elif node.is_standard_gate() and node.op.num_qubits == 2:
                 # Flush the two-qubit gate nodes into a group

--- a/samplomatic/transpiler/passes/group_meas_into_boxes.py
+++ b/samplomatic/transpiler/passes/group_meas_into_boxes.py
@@ -106,8 +106,9 @@ class GroupMeasIntoBoxes(TransformationPass):
         for node in dag.topological_op_nodes():
             validate_op_is_supported(node)
 
-            # The index of the earliest group able to collect ops on all the bits in this node
-            group_idx: int = max(group_indices[bit] for bit in node.qargs + node.cargs)
+            # The index of the earliest group able to collect ops on all the bits in this node.
+            # default=0 protects against ops with no qargs and no cargs (e.g. a zero-width barrier).
+            group_idx: int = max((group_indices[bit] for bit in node.qargs + node.cargs), default=0)
 
             if (name := node.op.name) in ["barrier", "box"] or (
                 node.is_standard_gate() and node.op.num_qubits == 2
@@ -122,8 +123,8 @@ class GroupMeasIntoBoxes(TransformationPass):
                 # Update trackers
                 for qubit in node.qargs:
                     group_indices[qubit] = group_idx + 1
-            elif node.is_standard_gate() and node.op.num_qubits == 1:
-                # Leave single-qubit gates alone
+            elif node.is_standard_gate() and node.op.num_qubits <= 1:
+                # Leave zero- and single-qubit gates alone (global phase gate is 0 qubits)
                 continue
             else:
                 raise TranspilerError(f"'{name}' operation is not supported.")

--- a/test/unit/test_transpiler/test_passes/test_group_gates_into_boxes.py
+++ b/test/unit/test_transpiler/test_passes/test_group_gates_into_boxes.py
@@ -1,6 +1,6 @@
 # This code is a Qiskit project.
 #
-# (C) Copyright IBM 2025.
+# (C) Copyright IBM 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -381,3 +381,28 @@ def test_raises_for_unsupported_ops():
 
     with pytest.raises(TranspilerError, match="``'if_else'`` is not supported"):
         pm.run(circuit)
+
+
+def test_global_phase_gate():
+    """Test that a GlobalPhaseGate passes through."""
+    from qiskit.circuit.library import GlobalPhaseGate
+
+    circuit = QuantumCircuit(2)
+    circuit.append(GlobalPhaseGate(0.1), [], [])
+    circuit.cx(0, 1)
+
+    pm = PassManager(passes=[GroupGatesIntoBoxes()])
+    assert any(op.name == "global_phase" for op in pm.run(circuit))
+
+
+def test_zero_width_barrier_passes_through():
+    """Test that a zero-width barrier does not crash and is left in place."""
+    circuit = QuantumCircuit(2)
+    circuit.cx(0, 1)
+    circuit.barrier([])
+    circuit.cx(0, 1)
+
+    pm = PassManager(passes=[GroupGatesIntoBoxes()])
+    result = pm.run(circuit)
+    # Both CX gates should end up boxed; zero-width barrier does not cause a crash
+    assert any(instr.operation.name == "box" for instr in result.data)

--- a/test/unit/test_transpiler/test_passes/test_group_meas_into_boxes.py
+++ b/test/unit/test_transpiler/test_passes/test_group_meas_into_boxes.py
@@ -1,6 +1,6 @@
 # This code is a Qiskit project.
 #
-# (C) Copyright IBM 2025.
+# (C) Copyright IBM 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -272,3 +272,28 @@ def test_raises_for_unsupported_ops():
 
     with pytest.raises(TranspilerError, match="``'if_else'`` is not supported"):
         pm.run(circuit)
+
+
+def test_global_phase_gate():
+    """Test that a GlobalPhaseGate passes through."""
+    from qiskit.circuit.library import GlobalPhaseGate
+
+    circuit = QuantumCircuit(1, 1)
+    circuit.append(GlobalPhaseGate(0.1), [], [])
+    circuit.measure(0, 0)
+
+    pm = PassManager(passes=[GroupMeasIntoBoxes()])
+    assert any(op.name == "global_phase" for op in pm.run(circuit))
+
+
+def test_zero_width_barrier_passes_through():
+    """Test that a zero-width barrier does not crash and is left in place."""
+    circuit = QuantumCircuit(2)
+    circuit.cx(0, 1)
+    circuit.barrier([])
+    circuit.measure_all()
+
+    pm = PassManager(passes=[GroupMeasIntoBoxes()])
+    result = pm.run(circuit)
+    # Both CX gates should end up boxed; zero-width barrier does not cause a crash
+    assert any(instr.operation.name == "barrier" for instr in result.data)


### PR DESCRIPTION
## Summary

This PR fixes #377 by making the pass manager pass them through instead of erroring.
This also fixes similar problems like 0-width barriers.

## Details and comments

This PR also updates the `build()` docstring to comment that removing the global phase attribute
is expected behaviour.