### PR TITLE
Support reset and delay instructions in ALAP boxing strategy

### DIFF
--- a/samplomatic/transpiler/passes/group_gates_into_boxes.py
+++ b/samplomatic/transpiler/passes/group_gates_into_boxes.py
@@ -14,6 +14,7 @@
 
 from collections import defaultdict
 from collections.abc import Iterable
+from enum import IntEnum
 from typing import Literal
 
 from qiskit.circuit import Annotation, Bit
@@ -30,6 +31,17 @@ from .utils import (
     make_and_insert_box,
     validate_op_is_supported,
 )
+
+
+class _TraversalDirection(IntEnum):
+    """The direction the DAG is scanned in.
+
+    Expressed as the offset applied to a group index each time a boundary is pushed further along
+    the traversal.
+    """
+
+    FORWARD = 1
+    BACKWARD = -1
 
 
 class GroupGatesIntoBoxes(TransformationPass):
@@ -77,30 +89,33 @@ class GroupGatesIntoBoxes(TransformationPass):
             *   When looping is complete, replace each group with a box.
         """
         if self.strategy == "alap":
-            return self._run_alap(dag)
-        return self._run_asap(dag)
+            return self._run(dag, alap_topological_nodes(dag), _TraversalDirection.BACKWARD)
+        return self._run(dag, asap_topological_nodes(dag), _TraversalDirection.FORWARD)
 
-    def _run_asap(self, dag: DAGCircuit) -> DAGCircuit:
-        # A list of groups that need to be placed in the same box, expressed as a dict for fast
-        # access. Every node in each group either contains a single- or two-qubit gate--when
-        # constructing this dictionary, we explicitly leave out nodes that contain different ops
+    def _run(
+        self, dag: DAGCircuit, ordered_nodes: Iterable[DAGOpNode], direction: _TraversalDirection
+    ) -> DAGCircuit:
+        # A list of groups that need to be placed in the same box
         groups: dict[int, list[DAGOpNode]] = defaultdict(list)
 
-        # A map from bits (qubits and clbits) to the index of the earliest group that is able to
-        # collect operations on those bits
+        # A map from bits to the index of the group that is able to collect operations on those bits
         group_indices: dict[Bit, int] = defaultdict(int)
 
-        for node in asap_topological_nodes(dag):
+        # How to compare groups in different traversal directions
+        pick_group = max if direction == _TraversalDirection.FORWARD else min
+
+        for node in ordered_nodes:
             validate_op_is_supported(node)
 
-            # The index of the earliest group able to collect ops on all the bits in this node.
-            # default=0 protects against ops with no qargs and no cargs (e.g. a zero-width barrier).
-            group_idx: int = max((group_indices[bit] for bit in node.qargs + node.cargs), default=0)
+            # The index of the group able to collect ops on all the bits in this node
+            group_idx: int = pick_group(
+                (group_indices[bit] for bit in node.qargs + node.cargs), default=0
+            )
 
             if (name := node.op.name) in ["barrier", "box"]:
-                # Flush the single-qubit gate nodes and place them in a group
+                # Flush: push the boundary one step further in the traversal direction
                 for qubit in node.qargs:
-                    group_indices[qubit] = group_idx + 1
+                    group_indices[qubit] = group_idx + direction
             elif name == "measure":
                 # Flush the single-qubit gate nodes without placing them in a group
                 qubit = node.qargs[0]
@@ -120,53 +135,7 @@ class GroupGatesIntoBoxes(TransformationPass):
 
                 # Update trackers
                 for qubit in node.qargs:
-                    group_indices[qubit] = group_idx + 1
-            else:
-                raise TranspilerError(f"'{name}' operation is not supported.")
-
-        for nodes in groups.values():
-            make_and_insert_box(dag, nodes, annotations=self.annotations)
-
-        return dag
-
-    def _run_alap(self, dag: DAGCircuit) -> DAGCircuit:
-        # Same structure as _run_asap but traversal is reversed: we iterate from the end of the
-        # circuit backward, and each gate is assigned to the latest group it can fit in.
-        groups: dict[int, list[DAGOpNode]] = defaultdict(list)
-
-        # A map from bits to the index of the latest group that is able to collect ops on those
-        # bits (starts at 0 and decrements as gates are assigned)
-        group_indices: dict[Bit, int] = defaultdict(int)
-
-        for node in alap_topological_nodes(dag):
-            validate_op_is_supported(node)
-
-            # The index of the latest group able to collect ops on all the bits in this node.
-            # default=0 protects against ops with no qargs and no cargs (e.g. a zero-width barrier).
-            group_idx: int = min(
-                (group_indices[bit] for bit in node.qargs + node.cargs), default=0
-            )
-
-            if (name := node.op.name) in ["barrier", "box"]:
-                # Flush: push the boundary one step earlier for all affected qubits
-                for qubit in node.qargs:
-                    group_indices[qubit] = group_idx - 1
-            elif name == "measure":
-                qubit = node.qargs[0]
-                clbit = node.cargs[0]
-
-                group_indices[qubit] = group_indices[clbit] = group_idx
-            elif name == "reset":
-                group_indices[node.qargs[0]] = group_idx
-            elif name == "delay":
-                continue
-            elif node.is_standard_gate() and node.op.num_qubits <= 1:
-                continue
-            elif node.is_standard_gate() and node.op.num_qubits == 2:
-                groups[group_idx].append(node)
-
-                for qubit in node.qargs:
-                    group_indices[qubit] = group_idx - 1
+                    group_indices[qubit] = group_idx + direction
             else:
                 raise TranspilerError(f"'{name}' operation is not supported.")
 

--- a/samplomatic/transpiler/passes/group_gates_into_boxes.py
+++ b/samplomatic/transpiler/passes/group_gates_into_boxes.py
@@ -141,8 +141,11 @@ class GroupGatesIntoBoxes(TransformationPass):
         for node in alap_topological_nodes(dag):
             validate_op_is_supported(node)
 
-            # The index of the latest group able to collect ops on all the bits in this node
-            group_idx: int = min(group_indices[bit] for bit in node.qargs + node.cargs)
+            # The index of the latest group able to collect ops on all the bits in this node.
+            # default=0 protects against ops with no qargs and no cargs (e.g. a zero-width barrier).
+            group_idx: int = min(
+                (group_indices[bit] for bit in node.qargs + node.cargs), default=0
+            )
 
             if (name := node.op.name) in ["barrier", "box"]:
                 # Flush: push the boundary one step earlier for all affected qubits
@@ -153,7 +156,11 @@ class GroupGatesIntoBoxes(TransformationPass):
                 clbit = node.cargs[0]
 
                 group_indices[qubit] = group_indices[clbit] = group_idx
-            elif node.is_standard_gate() and node.op.num_qubits == 1:
+            elif name == "reset":
+                group_indices[node.qargs[0]] = group_idx
+            elif name == "delay":
+                continue
+            elif node.is_standard_gate() and node.op.num_qubits <= 1:
                 continue
             elif node.is_standard_gate() and node.op.num_qubits == 2:
                 groups[group_idx].append(node)

--- a/test/unit/test_transpiler/test_passes/test_group_gates_into_boxes.py
+++ b/test/unit/test_transpiler/test_passes/test_group_gates_into_boxes.py
@@ -473,6 +473,40 @@ def make_alap_circuits():
 
     yield circuit, expected_circuit, "alap_circuit_with_measurements"
 
+    # Reset acts as a delimiter in ALAP: it syncs the qubit's group index at the current position
+    # without pushing it further. In reverse traversal: cx(1,2) → group 0; reset(1) syncs q1 at
+    # group 0 (no push); cx(0,1) touches q1 at 0 → group 0, but since it also assigns q0/q1 to
+    # group -1, the two CX gates land in separate boxes.
+    circuit = QuantumCircuit(3)
+    circuit.cx(0, 1)
+    circuit.reset(1)
+    circuit.cx(1, 2)
+
+    expected_circuit = QuantumCircuit(3)
+    with expected_circuit.box([Twirl(dressing="left")]):
+        expected_circuit.cx(0, 1)
+    expected_circuit.reset(1)
+    with expected_circuit.box([Twirl(dressing="left")]):
+        expected_circuit.cx(1, 2)
+
+    yield circuit, expected_circuit, "alap_circuit_with_reset"
+
+    # Delay is transparent in ALAP: it does not affect group assignment at all.
+    # In reverse traversal: cx(2,3) → group 0; delay on q2 is skipped; cx(0,1) shares no qubits
+    # with cx(2,3) → also group 0. Both land in the same box.
+    circuit = QuantumCircuit(4)
+    circuit.cx(0, 1)
+    circuit.delay(100, 2, unit="dt")
+    circuit.cx(2, 3)
+
+    expected_circuit = QuantumCircuit(4)
+    expected_circuit.delay(100, 2, unit="dt")
+    with expected_circuit.box([Twirl(dressing="left")]):
+        expected_circuit.cx(0, 1)
+        expected_circuit.cx(2, 3)
+
+    yield circuit, expected_circuit, "alap_circuit_with_delay"
+
 
 def test_raises_for_unsupported_ops():
     """Test that `GroupGatesIntoBoxes` raises when the circuit contains unsupported ops."""

--- a/test/unit/test_transpiler/test_passes/test_group_gates_into_boxes.py
+++ b/test/unit/test_transpiler/test_passes/test_group_gates_into_boxes.py
@@ -373,9 +373,6 @@ def make_alap_circuits():
     phi = Parameter("phi")
     lam = Parameter("lambda")
 
-    # In ASAP: cx(1,2)+cx(4,3) share no qubits → same box; ecr(0,1) follows in a second box.
-    # In ALAP: ecr(0,1) is latest → group 0; cx(1,2) shares q1 with ecr → pushed to group -1;
-    #          cx(4,3) shares no qubits with ecr → also lands in group 0 alongside ecr.
     circuit = QuantumCircuit(6)
     circuit.x(0)
     circuit.rx(theta, 0)
@@ -408,9 +405,6 @@ def make_alap_circuits():
 
     yield circuit, expected_circuit, "alap_groups_independent_gate_with_latest_box"
 
-    # Partial-width barrier: barrier(1,2) splits groups only on qubits 1 and 2.
-    # In ALAP: cx(2,3) is latest → group 0; barrier(1,2) pushes q1,q2 to group -1;
-    # cx(0,1) touches q1 which is now at -1 → group -1.
     circuit = QuantumCircuit(4)
     circuit.cx(0, 1)
     circuit.x(0)
@@ -433,7 +427,6 @@ def make_alap_circuits():
 
     yield circuit, expected_circuit, "alap_circuit_with_partial_width_barrier"
 
-    # Full-width barrier: all qubits flushed. CX gates on either side cannot merge.
     circuit = QuantumCircuit(4)
     circuit.cx(0, 1)
     circuit.barrier()
@@ -448,11 +441,6 @@ def make_alap_circuits():
 
     yield circuit, expected_circuit, "alap_circuit_with_full_width_barrier"
 
-    # Measurements as delimiters in ALAP mode.
-    # In ALAP traversal (reverse): cx(2,3) after barrier → group 0, cx(0,1) after barrier →
-    # group 0 (shares no constrained bits). Barrier pushes all to -1. Before barrier: cx(2,3)
-    # → group -1; measure syncs q1/c0 at -1 (no further push); cx(0,1) touches q1 at -1 →
-    # also group -1. So both pre-barrier CX gates share a box.
     circuit = QuantumCircuit(4, 1)
     circuit.cx(0, 1)
     circuit.measure(1, 0)
@@ -473,10 +461,6 @@ def make_alap_circuits():
 
     yield circuit, expected_circuit, "alap_circuit_with_measurements"
 
-    # Reset acts as a delimiter in ALAP: it syncs the qubit's group index at the current position
-    # without pushing it further. In reverse traversal: cx(1,2) → group 0; reset(1) syncs q1 at
-    # group 0 (no push); cx(0,1) touches q1 at 0 → group 0, but since it also assigns q0/q1 to
-    # group -1, the two CX gates land in separate boxes.
     circuit = QuantumCircuit(3)
     circuit.cx(0, 1)
     circuit.reset(1)
@@ -491,9 +475,6 @@ def make_alap_circuits():
 
     yield circuit, expected_circuit, "alap_circuit_with_reset"
 
-    # Delay is transparent in ALAP: it does not affect group assignment at all.
-    # In reverse traversal: cx(2,3) → group 0; delay on q2 is skipped; cx(0,1) shares no qubits
-    # with cx(2,3) → also group 0. Both land in the same box.
     circuit = QuantumCircuit(4)
     circuit.cx(0, 1)
     circuit.delay(100, 2, unit="dt")


### PR DESCRIPTION
The _run_alap method was missing handling for reset, delay, GlobalPhaseGate, and zero-width barriers that was added to _run_asap in PR #381. Cause was separation of PR #380 and #381.

## Summary

<!--
Fixes/Closes/Part of: #...
-->

## Details and comments
