### PR TITLE
Add `QuantumProgram` and related classes

### DIFF
--- a/changelog.d/396.added.md
+++ b/changelog.d/396.added.md
@@ -1,0 +1,1 @@
+Added `samplomatic.quantum_program` model to store `QuantumProgram`, `QuantumProgramResults`, and all the related classes.

--- a/changelog.d/396.added.md
+++ b/changelog.d/396.added.md
@@ -1,1 +1,1 @@
-Added `samplomatic.quantum_program` model to store `QuantumProgram`, `QuantumProgramResults`, and all the related classes.
+Added `samplomatic.quantum_program` module to store `QuantumProgram`, `QuantumProgramResults`, and all the related classes.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -21,6 +21,7 @@ Submodules
    samplomatic.graph_utils
    samplomatic.partition
    samplomatic.pre_samplex
+   samplomatic.quantum_program
    samplomatic.samplex
    samplomatic.serialization
    samplomatic.synths

--- a/docs/api/samplomatic.quantum_program.rst
+++ b/docs/api/samplomatic.quantum_program.rst
@@ -1,0 +1,6 @@
+samplomatic.quantum_program
+===========================
+
+.. automodapi:: samplomatic.quantum_program
+   :no-inheritance-diagram:
+   :no-heading:

--- a/samplomatic/__init__.py
+++ b/samplomatic/__init__.py
@@ -12,6 +12,7 @@
 
 """Samplomatic"""
 
+from . import quantum_program
 from ._version import __version__
 from .annotations import ChangeBasis, InjectNoise, Tag, Twirl
 from .builders import build

--- a/samplomatic/quantum_program/__init__.py
+++ b/samplomatic/quantum_program/__init__.py
@@ -53,4 +53,11 @@ and carries per-item metadata alongside the shared, program-level metadata store
 """
 
 from .quantum_program import CircuitItem, QuantumProgram, QuantumProgramItem, SamplexItem
-from .quantum_program_result import QuantumProgramItemResult, QuantumProgramResult
+from .quantum_program_result import (
+    ChunkPart,
+    ChunkSpan,
+    ChunkTiming,
+    Metadata,
+    QuantumProgramItemResult,
+    QuantumProgramResult,
+)

--- a/samplomatic/quantum_program/__init__.py
+++ b/samplomatic/quantum_program/__init__.py
@@ -1,0 +1,37 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Quantum Programs.
+
+Overview
+--------
+
+A quantum program consists of a list of ordered elements, each of which contains a single
+circuit and an array of associated parameter values. Executing a quantum program will
+sample the outcome of each circuit for the specified number of ``shots`` for each set of
+circuit arguments provided.
+
+
+Classes
+^^^^^^^
+
+.. autosummary::
+    :toctree: ../stubs/
+    :nosignatures:
+
+    QuantumProgram
+    QuantumProgramItem
+    CircuitItem
+    SamplexItem
+"""
+
+from .quantum_program import CircuitItem, QuantumProgram, QuantumProgramItem, SamplexItem

--- a/samplomatic/quantum_program/__init__.py
+++ b/samplomatic/quantum_program/__init__.py
@@ -57,7 +57,6 @@ from .quantum_program_result import (
     ChunkPart,
     ChunkSpan,
     ChunkTiming,
-    Metadata,
     QuantumProgramItemResult,
     QuantumProgramResult,
 )

--- a/samplomatic/quantum_program/__init__.py
+++ b/samplomatic/quantum_program/__init__.py
@@ -50,28 +50,6 @@ mirrors the program's structure: it holds one :class:`~.QuantumProgramItemResult
 item, in the same order. Each item result behaves like a mapping from output names to arrays,
 and carries per-item metadata alongside the shared, program-level metadata stored on the
 :class:`~.QuantumProgramResult`.
-
-
-Classes
-^^^^^^^
-
-.. autosummary::
-    :toctree: ../stubs/
-    :nosignatures:
-
-    QuantumProgram
-    QuantumProgramItem
-    CircuitItem
-    SamplexItem
-    QuantumProgramResult
-    QuantumProgramItemResult
-    ChunkTiming
-    ChunkSpan
-    ChunkPart
-    Metadata
-    ItemMetadata
-    SchedulerTiming
-    StretchValues
 """
 
 from .quantum_program import CircuitItem, QuantumProgram, QuantumProgramItem, SamplexItem

--- a/samplomatic/quantum_program/__init__.py
+++ b/samplomatic/quantum_program/__init__.py
@@ -15,10 +15,41 @@
 Overview
 --------
 
-A quantum program consists of a list of ordered elements, each of which contains a single
-circuit and an array of associated parameter values. Executing a quantum program will
-sample the outcome of each circuit for the specified number of ``shots`` for each set of
-circuit arguments provided.
+A :class:`~.QuantumProgram` is an ordered collection of items, where each item pairs a single
+circuit with the parameter data used to bind it. The program bundles these items together with
+shared settings such as the number of ``shots``, the classical-register measurement level, and
+optional noise maps, so that a whole family of related circuits can be described as one object.
+
+Every item is a :class:`~.QuantumProgramItem`, which comes in two flavors depending on how the
+circuit's parameters are supplied:
+
+* A :class:`~.CircuitItem` holds a circuit together with an explicit array of
+  ``circuit_arguments``. This is the natural choice when the parameter values are already known,
+  for instance a parameter sweep laid out on a grid.
+* A :class:`~.SamplexItem` holds a circuit together with a :class:`~samplomatic.samplex.Samplex`
+  that *generates* the circuit's parameters. This is the natural choice for randomized circuits,
+  such as Pauli twirling, where the concrete parameter values are drawn on demand rather than
+  fixed in advance.
+
+Shapes and broadcasting
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each item has a :attr:`~.QuantumProgramItem.shape`, obtained by broadcasting the *extrinsic*
+shapes of its inputs. Input arrays split their axes into extrinsic axes (leftmost, defining the
+sweep grid) and intrinsic axes (rightmost, fixed by the data type). For example,
+``circuit_arguments`` for a circuit with ``n`` parameters has intrinsic shape ``(n,)``, so an
+array of shape ``(5, 3, n)`` has extrinsic shape ``(5, 3)``. For a :class:`~.SamplexItem`, the
+``shape`` argument can enlarge the extrinsic grid beyond what the samplex arguments imply, with
+the extra axes enumerating independent randomizations.
+
+Results
+^^^^^^^
+
+The :class:`~.QuantumProgramResult` class collects the results associated with a program. This class
+mirrors the program's structure: it holds one :class:`~.QuantumProgramItemResult` per program
+item, in the same order. Each item result behaves like a mapping from output names to arrays,
+and carries per-item metadata alongside the shared, program-level metadata stored on the
+:class:`~.QuantumProgramResult`.
 
 
 Classes
@@ -32,6 +63,26 @@ Classes
     QuantumProgramItem
     CircuitItem
     SamplexItem
+    QuantumProgramResult
+    QuantumProgramItemResult
+    ChunkTiming
+    ChunkSpan
+    ChunkPart
+    Metadata
+    ItemMetadata
+    SchedulerTiming
+    StretchValues
 """
 
 from .quantum_program import CircuitItem, QuantumProgram, QuantumProgramItem, SamplexItem
+from .quantum_program_result import (
+    ChunkPart,
+    ChunkSpan,
+    ChunkTiming,
+    ItemMetadata,
+    Metadata,
+    QuantumProgramItemResult,
+    QuantumProgramResult,
+    SchedulerTiming,
+    StretchValues,
+)

--- a/samplomatic/quantum_program/__init__.py
+++ b/samplomatic/quantum_program/__init__.py
@@ -53,14 +53,4 @@ and carries per-item metadata alongside the shared, program-level metadata store
 """
 
 from .quantum_program import CircuitItem, QuantumProgram, QuantumProgramItem, SamplexItem
-from .quantum_program_result import (
-    ChunkPart,
-    ChunkSpan,
-    ChunkTiming,
-    ItemMetadata,
-    Metadata,
-    QuantumProgramItemResult,
-    QuantumProgramResult,
-    SchedulerTiming,
-    StretchValues,
-)
+from .quantum_program_result import QuantumProgramItemResult, QuantumProgramResult

--- a/samplomatic/quantum_program/datatree.py
+++ b/samplomatic/quantum_program/datatree.py
@@ -1,0 +1,24 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""DataTree."""
+
+from __future__ import annotations
+
+from typing import TypeAlias
+
+from numpy.typing import NDArray
+
+DataTree: TypeAlias = (
+    list["DataTree"] | dict[str, "DataTree"] | NDArray[float] | str | float | int | bool | None
+)
+"""Arbitrary nesting of lists and dicts with typed leaves."""

--- a/samplomatic/quantum_program/datatree.py
+++ b/samplomatic/quantum_program/datatree.py
@@ -14,9 +14,9 @@
 
 from typing import TypeAlias
 
-from numpy.typing import NDArray
+import numpy as np
 
 DataTree: TypeAlias = (
-    list["DataTree"] | dict[str, "DataTree"] | NDArray[float] | str | float | int | bool | None
+    list["DataTree"] | dict[str, "DataTree"] | np.ndarray[float] | str | float | int | bool | None
 )
 """Arbitrary nesting of lists and dicts with typed leaves."""

--- a/samplomatic/quantum_program/datatree.py
+++ b/samplomatic/quantum_program/datatree.py
@@ -12,8 +12,6 @@
 
 """DataTree."""
 
-from __future__ import annotations
-
 from typing import TypeAlias
 
 from numpy.typing import NDArray

--- a/samplomatic/quantum_program/quantum_program.py
+++ b/samplomatic/quantum_program/quantum_program.py
@@ -12,8 +12,6 @@
 
 """QuantumProgram."""
 
-from __future__ import annotations
-
 import abc
 import math
 from typing import TYPE_CHECKING, Any, Literal

--- a/samplomatic/quantum_program/quantum_program.py
+++ b/samplomatic/quantum_program/quantum_program.py
@@ -254,8 +254,8 @@ class QuantumProgram:
     def append_circuit_item(
         self,
         circuit: QuantumCircuit,
-        *,
         circuit_arguments: np.ndarray | None = None,
+        *,
         chunk_size: int | None = None,
     ) -> None:
         """Append a new :class:`CircuitItem` to this program.

--- a/samplomatic/quantum_program/quantum_program.py
+++ b/samplomatic/quantum_program/quantum_program.py
@@ -47,7 +47,7 @@ class QuantumProgramItem(abc.ABC):
     parameters has intrinsic shape ``(n,)``, so an array of shape ``(5, 3, n)`` has extrinsic
     shape ``(5, 3)``.
 
-    Output arrays returned by the executor follow the same convention: extrinsic axes match
+    Output arrays should follow the same convention: extrinsic axes match
     the item's :attr:`shape`, and intrinsic axes are determined by the output type (e.g.,
     ``(num_shots, creg_size)`` for classical register data).
 

--- a/samplomatic/quantum_program/quantum_program.py
+++ b/samplomatic/quantum_program/quantum_program.py
@@ -1,0 +1,342 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""QuantumProgram."""
+
+from __future__ import annotations
+
+import abc
+import math
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+from qiskit.circuit import QuantumCircuit
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from qiskit.quantum_info import PauliLindbladMap
+
+    from samplomatic.samplex import Samplex
+
+    from .datatree import DataTree
+
+
+def _desc_arr(arr: Any) -> str:
+    if hasattr(arr, "shape") and hasattr(arr, "dtype"):
+        return f"<{arr.shape}, {arr.dtype}>"
+    return f"<{type(arr).__name__}>"
+
+
+class QuantumProgramItem(abc.ABC):
+    """An item of a :class:`QuantumProgram`.
+
+    Each item has a :attr:`shape` that determines the number of circuit executions. This shape
+    is computed by broadcasting the *extrinsic* shapes of all input arrays. Input arrays have
+    both extrinsic axes (leftmost, defining the sweep grid) and intrinsic axes (rightmost,
+    determined by the data type). For example, ``circuit_arguments`` for a circuit with ``n``
+    parameters has intrinsic shape ``(n,)``, so an array of shape ``(5, 3, n)`` has extrinsic
+    shape ``(5, 3)``.
+
+    Output arrays returned by the executor follow the same convention: extrinsic axes match
+    the item's :attr:`shape`, and intrinsic axes are determined by the output type (e.g.,
+    ``(num_shots, creg_size)`` for classical register data).
+
+    Args:
+        circuit: The circuit to be executed.
+        chunk_size: The maximum number of bound circuits in each shot loop execution, or
+            ``None`` to use a server-side heuristic to optimize speed. When not executing
+            in a session, the server-side heuristic is always used and this value is ignored.
+    """
+
+    def __init__(self, circuit: QuantumCircuit, chunk_size: int | None = None):
+        if not isinstance(circuit, QuantumCircuit):
+            raise ValueError(f"Expected {repr(circuit)} to be a QuantumCircuit.")
+
+        self.circuit = circuit
+        self.chunk_size = chunk_size
+
+    @property
+    @abc.abstractmethod
+    def shape(self) -> tuple[int, ...]:
+        """The extrinsic shape of this item, i.e. the broadcasted extrinsic shapes of all inputs."""
+
+    def size(self) -> int:
+        """Return the total number elements in this item.
+
+        The size is calculated as the product of the entries of :attr:`~.shape`.
+        """
+        return math.prod(self.shape)
+
+
+class CircuitItem(QuantumProgramItem):
+    """An item of a :class:`QuantumProgram` containing a circuit and its arguments.
+
+    Args:
+        circuit: The circuit to be executed.
+        circuit_arguments: A real-valued array of parameter values for the circuit. The last axis
+            is intrinsic with size equal to the number of circuit parameters. Leading axes are
+            extrinsic and define the sweep grid. For example, shape ``(5, 3, n)`` means 5×3=15
+            configurations for a circuit with ``n`` parameters.
+        chunk_size: The maximum number of bound circuits in each shot loop execution, or
+            ``None`` to use a server-side heuristic to optimize speed. When not executing
+            in a session, the server-side heuristic is always used and this value is ignored.
+    """
+
+    def __init__(
+        self,
+        circuit: QuantumCircuit,
+        *,
+        circuit_arguments: np.ndarray | None = None,
+        chunk_size: int | None = None,
+    ):
+        super().__init__(circuit=circuit, chunk_size=chunk_size)
+
+        if circuit_arguments is None:
+            if circuit.num_parameters:
+                raise ValueError(
+                    f"{repr(circuit)} is parametric, but no 'circuit_arguments' were supplied."
+                )
+            circuit_arguments = []
+
+        circuit_arguments = np.array(circuit_arguments, dtype=float)
+
+        if circuit_arguments.shape[-1] != circuit.num_parameters:
+            raise ValueError(
+                "Expected the last axis of 'circuit_arguments' to have size "
+                f"{circuit.num_parameters} in order to match the number of parameters of the "
+                f"circuit, but found shape {circuit_arguments.shape} instead."
+            )
+
+        self.circuit_arguments = circuit_arguments
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """The extrinsic shape of this item, i.e. the broadcasted extrinsic shapes of all inputs."""
+        return self.circuit_arguments.shape[:-1]
+
+    def __repr__(self) -> str:
+        circuit = f"<QuantumCircuit @ {hex(id(self.circuit))}>"
+
+        if not self.circuit_arguments.size:
+            circuit_args = ""
+        else:
+            circuit_args = f", circuit_arguments={_desc_arr(self.circuit_arguments)}"
+
+        chunk_size = "" if self.chunk_size is None else f", chunk_size={self.chunk_size}"
+
+        return f"CircuitItem({circuit}{circuit_args}{chunk_size})"
+
+
+class SamplexItem(QuantumProgramItem):
+    """An item of a :class:`QuantumProgram` containing a circuit and samplex to feed it arguments.
+
+    Args:
+        circuit: The circuit to be executed.
+        samplex: A samplex to draw random parameters for the circuit.
+        samplex_arguments: A map from argument names to argument values for the samplex. Each
+            argument array has intrinsic axes determined by its type (e.g., ``parameter_values``
+            has intrinsic shape ``(n,)`` for ``n`` parameters, while scalar inputs like
+            ``noise_scale`` have intrinsic shape ``()``). The extrinsic shapes of all arguments
+            are broadcasted together following NumPy conventions.
+        shape: A shape that the item's extrinsic shape must be broadcastable to. Axes where
+            ``shape`` exceeds the shape implicit in ``samplex_arguments`` enumerate independent
+            randomizations.
+        chunk_size: The maximum number of bound circuits in each shot loop execution, or
+            ``None`` to use a server-side heuristic to optimize speed. When not executing
+            in a session, the server-side heuristic is always used and this value is
+            ignored.
+    """
+
+    def __init__(
+        self,
+        circuit: QuantumCircuit,
+        samplex: Samplex,
+        *,
+        samplex_arguments: dict[str, Any] | None = None,
+        shape: tuple[int, ...] | None = None,
+        chunk_size: int | None = None,
+    ):
+        super().__init__(circuit=circuit, chunk_size=chunk_size)
+
+        # Calling bind() here will do all Samplex validation
+        inputs = samplex.inputs().make_broadcastable().bind(**(samplex_arguments or {}))
+
+        if not inputs.fully_bound:
+            raise ValueError(
+                "The following required samplex arguments are missing:\n"
+                f"{inputs.describe(prefix='  * ', include_bound=False)}"
+            )
+
+        try:
+            self._shape = np.broadcast_shapes(shape or (), inputs.shape)
+        except ValueError as exc:
+            raise ValueError(
+                f"The provided shape {shape} must be broadcastable with the shape implicit in "
+                f"the sample_arguments, which is {inputs.shape}."
+            ) from exc
+
+        self.samplex = samplex
+        self.samplex_arguments = inputs
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """The extrinsic shape of this item, i.e. the broadcasted extrinsic shapes of all inputs."""
+        return self._shape
+
+    def __repr__(self) -> str:
+        circuit = f"<QuantumCircuit @ {hex(id(self.circuit))}>"
+
+        samplex = f", <Samplex @ {hex(id(self.samplex))}>" if self.samplex is not None else ""
+
+        if not self.samplex_arguments:
+            samplex_args = ""
+        else:
+            content = ", ".join(
+                f"'{name}'={_desc_arr(val)}" for name, val in self.samplex_arguments.items()
+            )
+            samplex_args = f", samplex_arguments={{{content}}}"
+
+        shape = f", shape={self.shape}"
+        chunk_size = "" if self.chunk_size is None else f", chunk_size={self.chunk_size}"
+
+        return f"SamplexItem({circuit}{samplex}{samplex_args}{shape}{chunk_size})"
+
+
+class QuantumProgram:
+    """A quantum runtime executable.
+
+    A quantum program consists of a list of ordered elements, each of which contains a single
+    circuit and an array of associated parameter values. Executing a quantum program will
+    sample the outcome of each circuit for the specified number of ``shots`` for each set of
+    circuit arguments provided.
+
+    Args:
+        shots: The number of shots for each circuit execution.
+        items: Items that comprise the program.
+        noise_maps: Noise maps to use with samplex items.
+        meas_level: The level at which to return all classical register measurement results. This
+            value sets the return type of all classical registers in all quantum program items and
+            determines whether the raw complex data from low-level measurement devices is
+            discriminated into bits or not. The supported values are
+
+                * "classified": Classical register data is returned as boolean arrays with the
+                    intrinsic shape ``(num_shots, creg_size)``.
+                * "kerneled": Classical register data is returned as a complex array with the
+                    intrinsic shape ``(num_shots, creg_size)``, where each entry represents an IQ
+                    data point (resulting from kerneling the measurement trace) in arbitrary units.
+                * "avg_kerneled": Classical register data is returned as a complex array with the
+                    intrinsic shape ``(creg_size,)``, where data is equivalent to "kerneled" except
+                    additionally averaged over shots.
+
+            passthrough_data: Arbitrary nested data passed through execution without modification.
+    """
+
+    def __init__(
+        self,
+        shots: int,
+        items: Iterable[QuantumProgramItem] | None = None,
+        noise_maps: dict[str, PauliLindbladMap] | None = None,
+        meas_level: Literal["classified", "kerneled", "avg_kerneled", "both"] = "classified",
+        passthrough_data: DataTree | None = None,
+    ):
+        self.shots = shots
+        self.items: list[QuantumProgramItem] = list(items or [])
+        self.noise_maps = noise_maps or {}
+        self.meas_level = meas_level
+        self.passthrough_data = passthrough_data
+
+        # Semantic role indicating how execution results may be post-processed by runtime clients.
+        # Reserved system values include 'sampler-v2' and 'estimator-v2', and are subject to change
+        # without notice. Third party clients should not set or depend on this value.
+        self._semantic_role: str | None = None
+
+    def append_circuit_item(
+        self,
+        circuit: QuantumCircuit,
+        *,
+        circuit_arguments: np.ndarray | None = None,
+        chunk_size: int | None = None,
+    ) -> None:
+        """Append a new :class:`CircuitItem` to this program.
+
+        Args:
+            circuit: The circuit of this item.
+            circuit_arguments: A real-valued array of parameter values for the circuit. The last
+                axis is intrinsic with size equal to the number of circuit parameters. Leading
+                axes are extrinsic and define the sweep grid.
+            chunk_size: The maximum number of bound circuits in each shot loop execution, or
+                ``None`` to use a server-side heuristic to optimize speed. When not executing
+                in a session, the server-side heuristic is always used and this value is ignored.
+        """
+        self.items.append(
+            CircuitItem(
+                circuit,
+                circuit_arguments=circuit_arguments,
+                chunk_size=chunk_size,
+            )
+        )
+
+    def append_samplex_item(
+        self,
+        circuit: QuantumCircuit,
+        *,
+        samplex: Samplex,
+        samplex_arguments: dict[str, Any] | None = None,
+        shape: tuple[int, ...] | None = None,
+        chunk_size: int | None = None,
+    ) -> None:
+        """Append a new :class:`SamplexItem` to this program.
+
+        Args:
+            circuit: The circuit of this item.
+            samplex: A samplex to draw random parameters for the circuit.
+            samplex_arguments: A map from argument names to argument values for the samplex. Each
+                argument array has intrinsic axes determined by its type (e.g., ``parameter_values``
+                has intrinsic shape ``(n,)`` for ``n`` parameters). The extrinsic shapes of all
+                arguments are broadcasted together.
+            shape: A shape that the item's extrinsic shape must be broadcastable to. Axes where
+                ``shape`` exceeds the shape implicit in ``samplex_arguments`` enumerate independent
+                randomizations.
+            chunk_size: The maximum number of bound circuits in each shot loop execution, or
+                ``None`` to use a server-side heuristic to optimize speed. When not executing
+                in a session, the server-side heuristic is always used and this value is ignored.
+        """
+        # add the noise maps first so that samplex_arguments has the ability to overwrite them
+        arguments = {
+            "pauli_lindblad_maps": {
+                noise_name: noise_model
+                for noise_name, noise_model in self.noise_maps.items()
+                if f"pauli_lindblad_maps.{noise_name}"
+                in [spec.name for spec in samplex.inputs().get_specs()]
+            }
+        }
+
+        arguments.update(samplex_arguments or {})
+        self.items.append(
+            SamplexItem(
+                circuit,
+                samplex,
+                samplex_arguments=arguments,
+                shape=shape,
+                chunk_size=chunk_size,
+            )
+        )
+
+    def __repr__(self) -> str:
+        if not self.items:
+            return f"QuantumProgram(shots={self.shots})"
+        return "\n".join(
+            [f"QuantumProgram(shots={self.shots}, items=["]
+            + [f"    {repr(item)}," for item in self.items]
+            + ["])"]
+        )

--- a/samplomatic/quantum_program/quantum_program.py
+++ b/samplomatic/quantum_program/quantum_program.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import abc
 import math
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from qiskit.circuit import QuantumCircuit
@@ -224,21 +224,7 @@ class QuantumProgram:
         shots: The number of shots for each circuit execution.
         items: Items that comprise the program.
         noise_maps: Noise maps to use with samplex items.
-        meas_level: The level at which to return all classical register measurement results. This
-            value sets the return type of all classical registers in all quantum program items and
-            determines whether the raw complex data from low-level measurement devices is
-            discriminated into bits or not. The supported values are
-
-                * "classified": Classical register data is returned as boolean arrays with the
-                    intrinsic shape ``(num_shots, creg_size)``.
-                * "kerneled": Classical register data is returned as a complex array with the
-                    intrinsic shape ``(num_shots, creg_size)``, where each entry represents an IQ
-                    data point (resulting from kerneling the measurement trace) in arbitrary units.
-                * "avg_kerneled": Classical register data is returned as a complex array with the
-                    intrinsic shape ``(creg_size,)``, where data is equivalent to "kerneled" except
-                    additionally averaged over shots.
-
-            passthrough_data: Arbitrary nested data passed through execution without modification.
+        passthrough_data: Arbitrary nested data passed through execution without modification.
     """
 
     def __init__(
@@ -246,13 +232,11 @@ class QuantumProgram:
         shots: int,
         items: Iterable[QuantumProgramItem] | None = None,
         noise_maps: dict[str, PauliLindbladMap] | None = None,
-        meas_level: Literal["classified", "kerneled", "avg_kerneled", "both"] = "classified",
         passthrough_data: DataTree | None = None,
     ):
         self.shots = shots
         self.items: list[QuantumProgramItem] = list(items or [])
         self.noise_maps = noise_maps or {}
-        self.meas_level = meas_level
         self.passthrough_data = passthrough_data
 
         # Semantic role indicating how execution results may be post-processed by runtime clients.

--- a/samplomatic/quantum_program/quantum_program.py
+++ b/samplomatic/quantum_program/quantum_program.py
@@ -239,11 +239,6 @@ class QuantumProgram:
         self.noise_maps = noise_maps or {}
         self.passthrough_data = passthrough_data
 
-        # Semantic role indicating how execution results may be post-processed by runtime clients.
-        # Reserved system values include 'sampler-v2' and 'estimator-v2', and are subject to change
-        # without notice. Third party clients should not set or depend on this value.
-        self._semantic_role: str | None = None
-
     def append_circuit_item(
         self,
         circuit: QuantumCircuit,

--- a/samplomatic/quantum_program/quantum_program.py
+++ b/samplomatic/quantum_program/quantum_program.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import abc
 import math
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 from qiskit.circuit import QuantumCircuit
@@ -224,6 +224,20 @@ class QuantumProgram:
         shots: The number of shots for each circuit execution.
         items: Items that comprise the program.
         noise_maps: Noise maps to use with samplex items.
+        meas_level: The level at which to return all classical register measurement results. This
+            value sets the return type of all classical registers in all quantum program items and
+            determines whether the raw complex data from low-level measurement devices is
+            discriminated into bits or not. The supported values are
+
+                * "classified": Classical register data is returned as boolean arrays with the
+                    intrinsic shape ``(num_shots, creg_size)``.
+                * "kerneled": Classical register data is returned as a complex array with the
+                    intrinsic shape ``(num_shots, creg_size)``, where each entry represents an IQ
+                    data point (resulting from kerneling the measurement trace) in arbitrary units.
+                * "avg_kerneled": Classical register data is returned as a complex array with the
+                    intrinsic shape ``(creg_size,)``, where data is equivalent to "kerneled" except
+                    additionally averaged over shots.
+
         passthrough_data: Arbitrary nested data passed through execution without modification.
     """
 
@@ -232,11 +246,13 @@ class QuantumProgram:
         shots: int,
         items: Iterable[QuantumProgramItem] | None = None,
         noise_maps: dict[str, PauliLindbladMap] | None = None,
+        meas_level: Literal["classified", "kerneled", "avg_kerneled", "both"] = "classified",
         passthrough_data: DataTree | None = None,
     ):
         self.shots = shots
         self.items: list[QuantumProgramItem] = list(items or [])
         self.noise_maps = noise_maps or {}
+        self.meas_level = meas_level
         self.passthrough_data = passthrough_data
 
     def append_circuit_item(

--- a/samplomatic/quantum_program/quantum_program.py
+++ b/samplomatic/quantum_program/quantum_program.py
@@ -222,7 +222,8 @@ class QuantumProgram:
         meas_level: The level at which to return all classical register measurement results. This
             value sets the return type of all classical registers in all quantum program items and
             determines whether the raw complex data from low-level measurement devices is
-            discriminated into bits or not. The supported values are
+            discriminated into bits or not. The allowed values are listed below; a backend should
+            provide support for `"classified"`, but may choose not to support others.
 
                 * "classified": Classical register data is returned as boolean arrays with the
                     intrinsic shape ``(num_shots, creg_size)``.

--- a/samplomatic/quantum_program/quantum_program.py
+++ b/samplomatic/quantum_program/quantum_program.py
@@ -14,19 +14,16 @@
 
 import abc
 import math
-from typing import TYPE_CHECKING, Any, Literal
+from collections.abc import Iterable
+from typing import Any, Literal
 
 import numpy as np
 from qiskit.circuit import QuantumCircuit
+from qiskit.quantum_info import PauliLindbladMap
 
-if TYPE_CHECKING:
-    from collections.abc import Iterable
+from samplomatic.samplex import Samplex
 
-    from qiskit.quantum_info import PauliLindbladMap
-
-    from samplomatic.samplex import Samplex
-
-    from .datatree import DataTree
+from .datatree import DataTree
 
 
 def _desc_arr(arr: Any) -> str:

--- a/samplomatic/quantum_program/quantum_program.py
+++ b/samplomatic/quantum_program/quantum_program.py
@@ -280,9 +280,9 @@ class QuantumProgram:
     def append_samplex_item(
         self,
         circuit: QuantumCircuit,
-        *,
         samplex: Samplex,
         samplex_arguments: dict[str, Any] | None = None,
+        *,
         shape: tuple[int, ...] | None = None,
         chunk_size: int | None = None,
     ) -> None:

--- a/samplomatic/quantum_program/quantum_program_result.py
+++ b/samplomatic/quantum_program/quantum_program_result.py
@@ -1,0 +1,376 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""QuantumProgramResult."""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, overload
+
+if TYPE_CHECKING:
+    import datetime
+    from collections.abc import Iterable, Iterator, Sequence
+    from datetime import timezone
+
+    import numpy as np
+    from plotly.graph_objects import Figure as PlotlyFigure
+
+    from .datatree import DataTree
+
+
+@dataclass
+class ChunkPart:
+    """A description of the contents of a single part of an execution chunk."""
+
+    idx_item: int
+    """The index of an item in a quantum program."""
+
+    size: int
+    """The number of elements from the quantum program item that were executed.
+
+    For example, if a quantum program item has shape ``(10, 5)``, then it has a total of ``50``
+    elements, so that if this ``size`` is ``10``, it constitutes 20% of the total work for the item.
+    """
+
+
+@dataclass
+class ChunkSpan:
+    """Timing information about a single chunk of execution.
+
+    .. note::
+
+        This span may include some amount of non-circuit time.
+    """
+
+    start: datetime.datetime
+    """The start time of the execution chunk in UTC."""
+
+    stop: datetime.datetime
+    """The stop time of the execution chunk in UTC."""
+
+    parts: list[ChunkPart]
+    """A description of which parts of a quantum program are contained in this chunk."""
+
+
+@dataclass
+class SchedulerTiming:
+    """The timing of a scheduled circuit.
+
+    All timing information is expressed in terms of multiples of the quantity ``dt``, time step
+    duration of the control electronics, which can be queried in backend and target properties.
+    """
+
+    timing: str
+    """A description of circuit timing in a comma-separated text format."""
+
+    circuit_duration: int
+    """The duration of the circuit in ``dt`` steps."""
+
+
+@dataclass
+class StretchValues:
+    """Circuit stretch value resolutions.
+
+    All timing information is expressed in terms of multiples of the quantity ``dt``, time step
+    duration of the control electronics, which can be queried in backend and target properties.
+    """
+
+    name: str
+    """The name of the stretch."""
+
+    value: int
+    """The resolved stretch value, up to the remainder, in units of ``dt``."""
+
+    remainder: int
+    """The time left over if ``value`` were to be used each stretch, in units of ``dt``."""
+
+    expanded_values: list[tuple[int, int]]
+    """A sequence of pairs ``(time, duration)`` indicating the time and duration of each delay.
+
+    All units are ``dt``, where the ``time`` denotes the absolute time of a delay in the circuit
+    schedule, and the ``duration`` denotes the total duration of the delay.
+    """
+
+
+@dataclass
+class ItemMetadata:
+    """Metadata about the execution of a single item of a quantum program."""
+
+    scheduler_timing: SchedulerTiming | None = None
+    """Scheduler circuit timing information, if it is available.
+
+    When available, the timing information can be visualized using the
+    :meth:`.qiskit_ibm_runtime.visualization.draw_circuit_schedule_timing` method
+    as in the snippet below.
+
+    .. code-block::python
+
+        from qiskit_ibm_runtime.visualization import draw_circuit_schedule_timing
+
+        # Retrieve the timings from the job item's metadata
+        result = job.result()
+        timings = result[0].metadata.scheduler_timing.timing
+
+        # Create a figure from the metadata
+        fig = draw_circuit_schedule_timing(
+            circuit_schedule=timings,
+            included_channels=None,
+            filter_readout_channels=False,
+            filter_barriers=False,
+            width=1000,
+        )
+
+    .. note::
+        This feature is experimental and subject to change without notice.
+    """
+
+    stretch_values: list[StretchValues] | None = None
+    """Stretch value resolution, if it is available.
+
+    .. note::
+        This feature is experimental and subject to change without notice.
+    """
+
+
+@dataclass
+class Metadata:
+    """Metadata about the execution of a quantum program run through the runtime executor."""
+
+    chunk_timing: list[ChunkSpan] = field(default_factory=list)
+    """Timing information about all executed chunks of a quantum program."""
+
+
+class ChunkTiming:
+    """A collection of chunk timing information for a :class:`QuantumProgramResult`.
+
+    This class is a readonly list-like containing :class:`~.ChunkSpan` objects, where each span
+    represents a single execution chunk on the backend and contains timing information and a
+    description of which parts of the :class:`~.QuantumProgram` were executed in that chunk.
+
+    To iterate over chunks:
+
+    .. code-block:: python
+
+        chunk_timings = job.result().timing
+        for chunk in chunk_timings:
+            print(chunk)
+
+    To draw the timings for a single result:
+
+    .. code-block:: python
+
+        chunk_timings.draw()
+
+    To draw the timings for several results on one plot:
+
+    .. code-block:: python
+
+        from qiskit_ibm_runtime.visualization import draw_chunk_timings
+
+        draw_chunk_timings(
+            chunk_timings1,
+            chunk_timings2,
+            names=["job 1", "job 2"],
+            common_start=True,
+        )
+    """
+
+    def __init__(self, spans: Iterable[ChunkSpan]):
+        self._spans = list(spans)
+
+    def __len__(self) -> int:
+        return len(self._spans)
+
+    @overload
+    def __getitem__(self, idxs: int) -> ChunkSpan: ...
+
+    @overload
+    def __getitem__(self, idxs: slice) -> ChunkTiming: ...
+
+    def __getitem__(self, idxs):  # type: ignore[no-untyped-def]
+        if isinstance(idxs, int):
+            return self._spans[idxs]
+        return ChunkTiming(self._spans[idxs])
+
+    def __iter__(self) -> Iterator[ChunkSpan]:
+        return iter(self._spans)
+
+    def __repr__(self) -> str:
+        return f"ChunkTiming({repr(self._spans)})"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, ChunkTiming) and self._spans == other._spans
+
+    @property
+    def start(self) -> datetime.datetime:
+        """The start time of the earliest chunk, in UTC."""
+        return min(span.start for span in self)
+
+    @property
+    def stop(self) -> datetime.datetime:
+        """The stop time of the latest chunk, in UTC."""
+        return max(span.stop for span in self)
+
+    @property
+    def duration(self) -> float:
+        """The total duration from first start to last stop, in seconds."""
+        return (self.stop - self.start).total_seconds()
+
+    def draw(
+        self,
+        name: str | None = None,
+        normalize_y: bool = False,
+        line_width: int = 4,
+        tz: timezone | None = None,
+    ) -> PlotlyFigure:
+        """Draw timing information on a bar plot.
+
+        To draw chunk timings with additional options like ``common_start``, or to draw
+        timings of several jobs on the same axis, consider calling
+        :meth:`~qiskit_ibm_runtime.visualization.draw_chunk_timings` directly.
+
+        Args:
+            name: A label for this set of chunks.
+            normalize_y: Whether to display the y-axis units as a percentage of work complete,
+                rather than cumulative elements completed.
+            line_width: The thickness of line segments.
+            tz: The timezone to use for displaying times. ``None`` (default) uses the local system
+                timezone. Pass ``datetime.timezone.utc`` to display times in UTC.
+
+        Returns:
+            A plotly figure.
+        """
+        from ..visualization import draw_chunk_timings
+
+        return draw_chunk_timings(
+            self, names=name, normalize_y=normalize_y, line_width=line_width, tz=tz
+        )
+
+
+class QuantumProgramItemResult(MutableMapping):
+    """A container to store results for a single item of a :class:`QuantumProgram`.
+
+    Args:
+        result: A dictionary with array-valued data.
+        metadata: The metadata produced for the individual item.
+    """
+
+    def __init__(
+        self,
+        result: dict[str, np.ndarray],
+        metadata: ItemMetadata | None = None,
+    ):
+        self._result = result
+        self.metadata = metadata or ItemMetadata()
+
+    def __getitem__(self, key: str) -> np.ndarray:
+        return self._result[key]
+
+    def __setitem__(self, key: str, value: np.array) -> None:
+        self._result[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._result[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._result)
+
+    def __len__(self) -> int:
+        return len(self._result)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._result}, metadata={self.metadata})"
+
+
+class QuantumProgramResult:
+    """A container to store results from executing a :class:`QuantumProgram`.
+
+    Args:
+        data: A list of dictionaries with array-valued data.
+        metadata: A dictionary of metadata.
+        passthrough_data: Arbitrary nested data passed through execution without modification.
+    """
+
+    def __init__(
+        self,
+        data: Sequence[dict[str, np.ndarray] | QuantumProgramItemResult],
+        metadata: Metadata | None = None,
+        passthrough_data: DataTree | None = None,
+    ):
+        self._data = [
+            datum
+            if isinstance(datum, QuantumProgramItemResult)
+            else QuantumProgramItemResult(datum)
+            for datum in data
+        ]
+        self.metadata = metadata or Metadata()
+        self.passthrough_data = passthrough_data
+
+        # Semantic role indicating how execution results may be post-processed by runtime clients.
+        # Reserved system values include 'sampler-v2' and 'estimator-v2', and are subject to change
+        # without notice. Third party clients should not set or depend on this value.
+        self._semantic_role: str | None = None
+
+    def __iter__(self) -> Iterator[QuantumProgramItemResult]:
+        yield from self._data
+
+    @overload
+    def __getitem__(self, idx: int) -> QuantumProgramItemResult: ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> list[QuantumProgramItemResult]: ...
+
+    def __getitem__(
+        self, idx: int | slice
+    ) -> QuantumProgramItemResult | list[QuantumProgramItemResult]:
+        return self._data[idx]
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(<{len(self)} results>)"
+
+    @property
+    def timing(self) -> ChunkTiming:
+        """Execution timing information of these results.
+
+        A single executor job may be broken up into chunks of work that are executed serially.
+        This property stores information about their timing. Most notably, for each chunk of
+        execution, a start and stop timestamp are provided that bound the window in which the data
+        was collected.
+
+        To draw the timings for a single result:
+
+        .. code-block:: python
+
+            job.result().timing.draw()
+
+        To draw the timings for several results on one plot:
+
+        .. code-block:: python
+
+            from qiskit_ibm_runtime.visualization import draw_chunk_timings
+
+            draw_chunk_timings(
+                job1.result().timing,
+                job2.result().timing,
+                names=["job 1", "job 2"],
+                common_start=True,
+            )
+
+        Returns:
+            A :class:`~.ChunkTiming` collection.
+        """
+        return ChunkTiming(self.metadata.chunk_timing)

--- a/samplomatic/quantum_program/quantum_program_result.py
+++ b/samplomatic/quantum_program/quantum_program_result.py
@@ -13,9 +13,9 @@
 """QuantumProgramResult."""
 
 from collections.abc import Iterable, Iterator, MutableMapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, overload
+from typing import overload
 
 import numpy as np
 from plotly.graph_objects import Figure as PlotlyFigure
@@ -55,14 +55,6 @@ class ChunkSpan:
 
     parts: list[ChunkPart]
     """A description of which parts of a quantum program are contained in this chunk."""
-
-
-@dataclass
-class Metadata:
-    """Metadata about the execution of a quantum program run through the executor."""
-
-    chunk_timing: list[ChunkSpan] = field(default_factory=list)
-    """Timing information about all executed chunks of a quantum program."""
 
 
 class ChunkTiming:
@@ -177,16 +169,10 @@ class QuantumProgramItemResult(MutableMapping):
 
     Args:
         result: A dictionary with array-valued data.
-        metadata: The metadata produced for the individual item.
     """
 
-    def __init__(
-        self,
-        result: dict[str, np.ndarray],
-        metadata: Any = None,
-    ):
+    def __init__(self, result: dict[str, np.ndarray]):
         self._result = result
-        self.metadata = metadata
 
     def __getitem__(self, key: str) -> np.ndarray:
         return self._result[key]
@@ -204,7 +190,7 @@ class QuantumProgramItemResult(MutableMapping):
         return len(self._result)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self._result}, metadata={self.metadata})"
+        return f"{self.__class__.__name__}({self._result})"
 
 
 class QuantumProgramResult:
@@ -212,14 +198,12 @@ class QuantumProgramResult:
 
     Args:
         data: A list of dictionaries with array-valued data.
-        metadata: The result metadata.
         passthrough_data: Arbitrary nested data passed through execution without modification.
     """
 
     def __init__(
         self,
         data: Sequence[dict[str, np.ndarray] | QuantumProgramItemResult],
-        metadata: Metadata | None = None,
         passthrough_data: DataTree | None = None,
     ):
         self._data = [
@@ -228,7 +212,6 @@ class QuantumProgramResult:
             else QuantumProgramItemResult(datum)
             for datum in data
         ]
-        self.metadata = metadata or Metadata()
         self.passthrough_data = passthrough_data
 
     def __iter__(self) -> Iterator[QuantumProgramItemResult]:
@@ -282,4 +265,4 @@ class QuantumProgramResult:
         Returns:
             A :class:`~.ChunkTiming` collection.
         """
-        return ChunkTiming(self.metadata.chunk_timing)
+        raise NotImplementedError("Not implemented.")

--- a/samplomatic/quantum_program/quantum_program_result.py
+++ b/samplomatic/quantum_program/quantum_program_result.py
@@ -15,247 +15,14 @@
 from __future__ import annotations
 
 from collections.abc import MutableMapping
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, Any, overload
 
 if TYPE_CHECKING:
-    import datetime
-    from collections.abc import Iterable, Iterator, Sequence
-    from datetime import timezone
+    from collections.abc import Iterator, Sequence
 
     import numpy as np
-    from plotly.graph_objects import Figure as PlotlyFigure
 
     from .datatree import DataTree
-
-
-@dataclass
-class ChunkPart:
-    """A description of the contents of a single part of an execution chunk."""
-
-    idx_item: int
-    """The index of an item in a quantum program."""
-
-    size: int
-    """The number of elements from the quantum program item that were executed.
-
-    For example, if a quantum program item has shape ``(10, 5)``, then it has a total of ``50``
-    elements, so that if this ``size`` is ``10``, it constitutes 20% of the total work for the item.
-    """
-
-
-@dataclass
-class ChunkSpan:
-    """Timing information about a single chunk of execution.
-
-    .. note::
-
-        This span may include some amount of non-circuit time.
-    """
-
-    start: datetime.datetime
-    """The start time of the execution chunk in UTC."""
-
-    stop: datetime.datetime
-    """The stop time of the execution chunk in UTC."""
-
-    parts: list[ChunkPart]
-    """A description of which parts of a quantum program are contained in this chunk."""
-
-
-@dataclass
-class SchedulerTiming:
-    """The timing of a scheduled circuit.
-
-    All timing information is expressed in terms of multiples of the quantity ``dt``, time step
-    duration of the control electronics, which can be queried in backend and target properties.
-    """
-
-    timing: str
-    """A description of circuit timing in a comma-separated text format."""
-
-    circuit_duration: int
-    """The duration of the circuit in ``dt`` steps."""
-
-
-@dataclass
-class StretchValues:
-    """Circuit stretch value resolutions.
-
-    All timing information is expressed in terms of multiples of the quantity ``dt``, time step
-    duration of the control electronics, which can be queried in backend and target properties.
-    """
-
-    name: str
-    """The name of the stretch."""
-
-    value: int
-    """The resolved stretch value, up to the remainder, in units of ``dt``."""
-
-    remainder: int
-    """The time left over if ``value`` were to be used each stretch, in units of ``dt``."""
-
-    expanded_values: list[tuple[int, int]]
-    """A sequence of pairs ``(time, duration)`` indicating the time and duration of each delay.
-
-    All units are ``dt``, where the ``time`` denotes the absolute time of a delay in the circuit
-    schedule, and the ``duration`` denotes the total duration of the delay.
-    """
-
-
-@dataclass
-class ItemMetadata:
-    """Metadata about the execution of a single item of a quantum program."""
-
-    scheduler_timing: SchedulerTiming | None = None
-    """Scheduler circuit timing information, if it is available.
-
-    When available, the timing information can be visualized using the
-    :meth:`.qiskit_ibm_runtime.visualization.draw_circuit_schedule_timing` method
-    as in the snippet below.
-
-    .. code-block::python
-
-        from qiskit_ibm_runtime.visualization import draw_circuit_schedule_timing
-
-        # Retrieve the timings from the job item's metadata
-        result = job.result()
-        timings = result[0].metadata.scheduler_timing.timing
-
-        # Create a figure from the metadata
-        fig = draw_circuit_schedule_timing(
-            circuit_schedule=timings,
-            included_channels=None,
-            filter_readout_channels=False,
-            filter_barriers=False,
-            width=1000,
-        )
-
-    .. note::
-        This feature is experimental and subject to change without notice.
-    """
-
-    stretch_values: list[StretchValues] | None = None
-    """Stretch value resolution, if it is available.
-
-    .. note::
-        This feature is experimental and subject to change without notice.
-    """
-
-
-@dataclass
-class Metadata:
-    """Metadata about the execution of a quantum program run through the runtime executor."""
-
-    chunk_timing: list[ChunkSpan] = field(default_factory=list)
-    """Timing information about all executed chunks of a quantum program."""
-
-
-class ChunkTiming:
-    """A collection of chunk timing information for a :class:`QuantumProgramResult`.
-
-    This class is a readonly list-like containing :class:`~.ChunkSpan` objects, where each span
-    represents a single execution chunk on the backend and contains timing information and a
-    description of which parts of the :class:`~.QuantumProgram` were executed in that chunk.
-
-    To iterate over chunks:
-
-    .. code-block:: python
-
-        chunk_timings = job.result().timing
-        for chunk in chunk_timings:
-            print(chunk)
-
-    To draw the timings for a single result:
-
-    .. code-block:: python
-
-        chunk_timings.draw()
-
-    To draw the timings for several results on one plot:
-
-    .. code-block:: python
-
-        from qiskit_ibm_runtime.visualization import draw_chunk_timings
-
-        draw_chunk_timings(
-            chunk_timings1,
-            chunk_timings2,
-            names=["job 1", "job 2"],
-            common_start=True,
-        )
-    """
-
-    def __init__(self, spans: Iterable[ChunkSpan]):
-        self._spans = list(spans)
-
-    def __len__(self) -> int:
-        return len(self._spans)
-
-    @overload
-    def __getitem__(self, idxs: int) -> ChunkSpan: ...
-
-    @overload
-    def __getitem__(self, idxs: slice) -> ChunkTiming: ...
-
-    def __getitem__(self, idxs):  # type: ignore[no-untyped-def]
-        if isinstance(idxs, int):
-            return self._spans[idxs]
-        return ChunkTiming(self._spans[idxs])
-
-    def __iter__(self) -> Iterator[ChunkSpan]:
-        return iter(self._spans)
-
-    def __repr__(self) -> str:
-        return f"ChunkTiming({repr(self._spans)})"
-
-    def __eq__(self, other: object) -> bool:
-        return isinstance(other, ChunkTiming) and self._spans == other._spans
-
-    @property
-    def start(self) -> datetime.datetime:
-        """The start time of the earliest chunk, in UTC."""
-        return min(span.start for span in self)
-
-    @property
-    def stop(self) -> datetime.datetime:
-        """The stop time of the latest chunk, in UTC."""
-        return max(span.stop for span in self)
-
-    @property
-    def duration(self) -> float:
-        """The total duration from first start to last stop, in seconds."""
-        return (self.stop - self.start).total_seconds()
-
-    def draw(
-        self,
-        name: str | None = None,
-        normalize_y: bool = False,
-        line_width: int = 4,
-        tz: timezone | None = None,
-    ) -> PlotlyFigure:
-        """Draw timing information on a bar plot.
-
-        To draw chunk timings with additional options like ``common_start``, or to draw
-        timings of several jobs on the same axis, consider calling
-        :meth:`~qiskit_ibm_runtime.visualization.draw_chunk_timings` directly.
-
-        Args:
-            name: A label for this set of chunks.
-            normalize_y: Whether to display the y-axis units as a percentage of work complete,
-                rather than cumulative elements completed.
-            line_width: The thickness of line segments.
-            tz: The timezone to use for displaying times. ``None`` (default) uses the local system
-                timezone. Pass ``datetime.timezone.utc`` to display times in UTC.
-
-        Returns:
-            A plotly figure.
-        """
-        from ..visualization import draw_chunk_timings
-
-        return draw_chunk_timings(
-            self, names=name, normalize_y=normalize_y, line_width=line_width, tz=tz
-        )
 
 
 class QuantumProgramItemResult(MutableMapping):
@@ -269,10 +36,10 @@ class QuantumProgramItemResult(MutableMapping):
     def __init__(
         self,
         result: dict[str, np.ndarray],
-        metadata: ItemMetadata | None = None,
+        metadata: Any = None,
     ):
         self._result = result
-        self.metadata = metadata or ItemMetadata()
+        self.metadata = metadata
 
     def __getitem__(self, key: str) -> np.ndarray:
         return self._result[key]
@@ -305,7 +72,7 @@ class QuantumProgramResult:
     def __init__(
         self,
         data: Sequence[dict[str, np.ndarray] | QuantumProgramItemResult],
-        metadata: Metadata | None = None,
+        metadata: Any = None,
         passthrough_data: DataTree | None = None,
     ):
         self._data = [
@@ -314,7 +81,7 @@ class QuantumProgramResult:
             else QuantumProgramItemResult(datum)
             for datum in data
         ]
-        self.metadata = metadata or Metadata()
+        self.metadata = metadata
         self.passthrough_data = passthrough_data
 
         # Semantic role indicating how execution results may be post-processed by runtime clients.
@@ -341,36 +108,3 @@ class QuantumProgramResult:
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(<{len(self)} results>)"
-
-    @property
-    def timing(self) -> ChunkTiming:
-        """Execution timing information of these results.
-
-        A single executor job may be broken up into chunks of work that are executed serially.
-        This property stores information about their timing. Most notably, for each chunk of
-        execution, a start and stop timestamp are provided that bound the window in which the data
-        was collected.
-
-        To draw the timings for a single result:
-
-        .. code-block:: python
-
-            job.result().timing.draw()
-
-        To draw the timings for several results on one plot:
-
-        .. code-block:: python
-
-            from qiskit_ibm_runtime.visualization import draw_chunk_timings
-
-            draw_chunk_timings(
-                job1.result().timing,
-                job2.result().timing,
-                names=["job 1", "job 2"],
-                common_start=True,
-            )
-
-        Returns:
-            A :class:`~.ChunkTiming` collection.
-        """
-        return ChunkTiming(self.metadata.chunk_timing)

--- a/samplomatic/quantum_program/quantum_program_result.py
+++ b/samplomatic/quantum_program/quantum_program_result.py
@@ -12,15 +12,12 @@
 
 """QuantumProgramResult."""
 
-from collections.abc import MutableMapping
-from typing import TYPE_CHECKING, Any, overload
+from collections.abc import Iterator, MutableMapping, Sequence
+from typing import Any, overload
 
-if TYPE_CHECKING:
-    from collections.abc import Iterator, Sequence
+import numpy as np
 
-    import numpy as np
-
-    from .datatree import DataTree
+from .datatree import DataTree
 
 
 class QuantumProgramItemResult(MutableMapping):

--- a/samplomatic/quantum_program/quantum_program_result.py
+++ b/samplomatic/quantum_program/quantum_program_result.py
@@ -12,12 +12,164 @@
 
 """QuantumProgramResult."""
 
-from collections.abc import Iterator, MutableMapping, Sequence
+from collections.abc import Iterable, Iterator, MutableMapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any, overload
 
 import numpy as np
+from plotly.graph_objects import Figure as PlotlyFigure
 
 from .datatree import DataTree
+
+
+@dataclass
+class ChunkPart:
+    """A description of the contents of a single part of an execution chunk."""
+
+    idx_item: int
+    """The index of an item in a quantum program."""
+
+    size: int
+    """The number of elements from the quantum program item that were executed.
+
+    For example, if a quantum program item has shape ``(10, 5)``, then it has a total of ``50``
+    elements, so that if this ``size`` is ``10``, it constitutes 20% of the total work for the item.
+    """
+
+
+@dataclass
+class ChunkSpan:
+    """Timing information about a single chunk of execution.
+
+    .. note::
+
+        This span may include some amount of non-circuit time.
+    """
+
+    start: datetime
+    """The start time of the execution chunk in UTC."""
+
+    stop: datetime
+    """The stop time of the execution chunk in UTC."""
+
+    parts: list[ChunkPart]
+    """A description of which parts of a quantum program are contained in this chunk."""
+
+
+@dataclass
+class Metadata:
+    """Metadata about the execution of a quantum program run through the runtime executor."""
+
+    chunk_timing: list[ChunkSpan] = field(default_factory=list)
+    """Timing information about all executed chunks of a quantum program."""
+
+
+class ChunkTiming:
+    """A collection of chunk timing information for a :class:`QuantumProgramResult`.
+
+    This class is a readonly list-like containing :class:`~.ChunkSpan` objects, where each span
+    represents a single execution chunk on the backend and contains timing information and a
+    description of which parts of the :class:`~.QuantumProgram` were executed in that chunk.
+
+    To iterate over chunks:
+
+    .. code-block:: python
+
+        chunk_timings = job.result().timing
+        for chunk in chunk_timings:
+            print(chunk)
+
+    To draw the timings for a single result:
+
+    .. code-block:: python
+
+        chunk_timings.draw()
+
+    To draw the timings for several results on one plot:
+
+    .. code-block:: python
+
+        from samplomatic.visualization.draw_chunk_timings import draw_chunk_timings
+
+        draw_chunk_timings(
+            chunk_timings1,
+            chunk_timings2,
+            names=["job 1", "job 2"],
+            common_start=True,
+        )
+    """
+
+    def __init__(self, spans: Iterable[ChunkSpan]):
+        self._spans = list(spans)
+
+    def __len__(self) -> int:
+        return len(self._spans)
+
+    @overload
+    def __getitem__(self, idxs: int) -> ChunkSpan: ...
+
+    @overload
+    def __getitem__(self, idxs: slice) -> "ChunkTiming": ...
+
+    def __getitem__(self, idxs):  # type: ignore[no-untyped-def]
+        if isinstance(idxs, int):
+            return self._spans[idxs]
+        return ChunkTiming(self._spans[idxs])
+
+    def __iter__(self) -> Iterator[ChunkSpan]:
+        return iter(self._spans)
+
+    def __repr__(self) -> str:
+        return f"ChunkTiming({repr(self._spans)})"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, ChunkTiming) and self._spans == other._spans
+
+    @property
+    def start(self) -> datetime:
+        """The start time of the earliest chunk, in UTC."""
+        return min(span.start for span in self)
+
+    @property
+    def stop(self) -> datetime:
+        """The stop time of the latest chunk, in UTC."""
+        return max(span.stop for span in self)
+
+    @property
+    def duration(self) -> float:
+        """The total duration from first start to last stop, in seconds."""
+        return (self.stop - self.start).total_seconds()
+
+    def draw(
+        self,
+        name: str | None = None,
+        normalize_y: bool = False,
+        line_width: int = 4,
+        tz: timezone | None = None,
+    ) -> PlotlyFigure:
+        """Draw timing information on a bar plot.
+
+        To draw chunk timings with additional options like ``common_start``, or to draw
+        timings of several jobs on the same axis, consider calling
+        :meth:`~samplomatic.visualization.draw_chunk_timings` directly.
+
+        Args:
+            name: A label for this set of chunks.
+            normalize_y: Whether to display the y-axis units as a percentage of work complete,
+                rather than cumulative elements completed.
+            line_width: The thickness of line segments.
+            tz: The timezone to use for displaying times. ``None`` (default) uses the local system
+                timezone. Pass ``datetime.timezone.utc`` to display times in UTC.
+
+        Returns:
+            A plotly figure.
+        """
+        from ..visualization.draw_chunk_timings import draw_chunk_timings
+
+        return draw_chunk_timings(
+            self, names=name, normalize_y=normalize_y, line_width=line_width, tz=tz
+        )
 
 
 class QuantumProgramItemResult(MutableMapping):
@@ -67,7 +219,7 @@ class QuantumProgramResult:
     def __init__(
         self,
         data: Sequence[dict[str, np.ndarray] | QuantumProgramItemResult],
-        metadata: Any = None,
+        metadata: Metadata | None = None,
         passthrough_data: DataTree | None = None,
     ):
         self._data = [
@@ -76,7 +228,7 @@ class QuantumProgramResult:
             else QuantumProgramItemResult(datum)
             for datum in data
         ]
-        self.metadata = metadata
+        self.metadata = metadata or Metadata()
         self.passthrough_data = passthrough_data
 
     def __iter__(self) -> Iterator[QuantumProgramItemResult]:
@@ -98,3 +250,36 @@ class QuantumProgramResult:
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(<{len(self)} results>)"
+
+    @property
+    def timing(self) -> ChunkTiming:
+        """Execution timing information of these results.
+
+        A single executor job may be broken up into chunks of work that are executed serially.
+        This property stores information about their timing. Most notably, for each chunk of
+        execution, a start and stop timestamp are provided that bound the window in which the data
+        was collected.
+
+        To draw the timings for a single result:
+
+        .. code-block:: python
+
+            job.result().timing.draw()
+
+        To draw the timings for several results on one plot:
+
+        .. code-block:: python
+
+            from samplomatic.visualization.draw_chunk_timings import draw_chunk_timings
+
+            draw_chunk_timings(
+                job1.result().timing,
+                job2.result().timing,
+                names=["job 1", "job 2"],
+                common_start=True,
+            )
+
+        Returns:
+            A :class:`~.ChunkTiming` collection.
+        """
+        return ChunkTiming(self.metadata.chunk_timing)

--- a/samplomatic/quantum_program/quantum_program_result.py
+++ b/samplomatic/quantum_program/quantum_program_result.py
@@ -12,8 +12,6 @@
 
 """QuantumProgramResult."""
 
-from __future__ import annotations
-
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, overload
 

--- a/samplomatic/quantum_program/quantum_program_result.py
+++ b/samplomatic/quantum_program/quantum_program_result.py
@@ -84,11 +84,6 @@ class QuantumProgramResult:
         self.metadata = metadata
         self.passthrough_data = passthrough_data
 
-        # Semantic role indicating how execution results may be post-processed by runtime clients.
-        # Reserved system values include 'sampler-v2' and 'estimator-v2', and are subject to change
-        # without notice. Third party clients should not set or depend on this value.
-        self._semantic_role: str | None = None
-
     def __iter__(self) -> Iterator[QuantumProgramItemResult]:
         yield from self._data
 

--- a/samplomatic/quantum_program/quantum_program_result.py
+++ b/samplomatic/quantum_program/quantum_program_result.py
@@ -60,7 +60,7 @@ class QuantumProgramResult:
 
     Args:
         data: A list of dictionaries with array-valued data.
-        metadata: A dictionary of metadata.
+        metadata: The result metadata.
         passthrough_data: Arbitrary nested data passed through execution without modification.
     """
 

--- a/samplomatic/quantum_program/quantum_program_result.py
+++ b/samplomatic/quantum_program/quantum_program_result.py
@@ -59,7 +59,7 @@ class ChunkSpan:
 
 @dataclass
 class Metadata:
-    """Metadata about the execution of a quantum program run through the runtime executor."""
+    """Metadata about the execution of a quantum program run through the executor."""
 
     chunk_timing: list[ChunkSpan] = field(default_factory=list)
     """Timing information about all executed chunks of a quantum program."""

--- a/samplomatic/visualization/draw_chunk_timings.py
+++ b/samplomatic/visualization/draw_chunk_timings.py
@@ -1,0 +1,193 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""draw_chunk_timings"""
+
+from collections.abc import Iterable
+from datetime import datetime, timedelta, timezone
+from itertools import cycle
+from typing import TYPE_CHECKING
+
+from ..optionals import HAS_PLOTLY
+from ..quantum_program import ChunkSpan, ChunkTiming
+
+if TYPE_CHECKING:
+    from plotly.graph_objects import Figure
+
+
+_HOVER_HEADER = "<br>".join(
+    [
+        "<b>{name}[{idx}]</b>",
+        "<b>&nbsp;&nbsp;&nbsp;Start:</b> {start:%Y-%m-%d %H:%M:%S.%f}",
+        "<b>&nbsp;&nbsp;&nbsp;Stop:</b> {stop:%Y-%m-%d %H:%M:%S.%f}",
+        "<b>&nbsp;&nbsp;&nbsp;Duration:</b> {duration:.4g}s",
+        "<b>&nbsp;&nbsp;&nbsp;Size:</b> {size}",
+        "<b>&nbsp;&nbsp;&nbsp;Parts ({n_parts}):</b>",
+    ]
+)
+_HOVER_PART = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;item[{idx_item}]: {size}"
+_HOVER_ELLIPSIS = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;..."
+_PARTS_LIMIT = 10
+
+
+def _apply_tz(dt: datetime, tz: timezone | None) -> datetime:
+    """Convert a datetime (assumed UTC if naive) to the given timezone, stripped of tzinfo.
+
+    Args:
+        dt: The datetime to convert. Treated as UTC if timezone-naive.
+        tz: Target timezone. ``None`` means the local system timezone.
+
+    Returns:
+        A timezone-naive datetime in the target timezone.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(tz=tz).replace(tzinfo=None)
+
+
+def _format_hover(name: str, idx: int, chunk: ChunkSpan, tz: timezone | None) -> str:
+    chunk_size = sum(p.size for p in chunk.parts)
+    duration = (chunk.stop - chunk.start).total_seconds()
+    lines = [
+        _HOVER_HEADER.format(
+            name=name,
+            idx=idx,
+            start=_apply_tz(chunk.start, tz),
+            stop=_apply_tz(chunk.stop, tz),
+            duration=duration,
+            size=chunk_size,
+            n_parts=len(chunk.parts),
+        )
+    ]
+    for part in chunk.parts[:_PARTS_LIMIT]:
+        lines.append(_HOVER_PART.format(idx_item=part.idx_item, size=part.size))
+    if len(chunk.parts) > _PARTS_LIMIT:
+        lines.append(_HOVER_ELLIPSIS)
+    return "<br>".join(lines)
+
+
+@HAS_PLOTLY.require_in_call
+def draw_chunk_timings(
+    *timings: ChunkTiming,
+    names: str | Iterable[str] | None = None,
+    common_start: bool = False,
+    normalize_y: bool = False,
+    line_width: int = 4,
+    show_legend: bool | None = None,
+    tz: timezone | None = None,
+) -> "Figure":
+    """Draw one or more :class:`~.ChunkTiming` on a bar plot.
+
+    Each chunk corresponds to a single execution window on the backend. The y-axis represents
+    cumulative work completed across chunks — in units of elements executed, or as a percentage
+    if ``normalize_y=True``.
+
+    When comparing multiple :class:`~.ChunkTiming` (e.g. from different jobs), use
+    ``common_start=True`` to align traces at :math:`t=0` for direct comparison.
+
+    .. note::
+
+        For a simpler single-trace interface for data from an executor job, call
+        :meth:`~.ChunkTiming.draw` directly on ``job.result().timings``.
+
+    Args:
+        timings: One or more :class:`~.ChunkTiming` collections.
+        names: Name or names to assign to the respective ``timings``. When provided, a
+            legend is shown by default.
+        common_start: Whether to shift each collection's chunks so that its first chunk starts
+            at :math:`t=0`. Useful for comparing timings from different jobs side by side.
+        normalize_y: Whether to display the y-axis units as a percentage of work complete,
+            rather than cumulative elements completed.
+        line_width: The thickness of line segments.
+        show_legend: Whether to show a legend. By default, shown only when ``names`` is provided.
+        tz: The timezone to use for displaying times. ``None`` (default) uses the local system
+            timezone. Pass ``datetime.timezone.utc`` to display times in UTC.
+
+    Returns:
+        A plotly figure.
+    """
+    import plotly.colors as _colors  # pylint: disable=import-outside-toplevel
+    import plotly.graph_objects as go  # pylint: disable=import-outside-toplevel
+
+    colors = _colors.qualitative.Plotly
+
+    fig = go.Figure()
+
+    # resolve names and legend visibility
+    all_names: list[str] = []
+    if names is None:
+        show_legend = False if show_legend is None else show_legend
+    else:
+        show_legend = True if show_legend is None else show_legend
+        if isinstance(names, str):
+            all_names = [names]
+        else:
+            all_names.extend(names)
+
+    # fill in default names for any without an explicit one
+    all_names.extend(f"Timings {idx}" for idx in range(len(all_names), len(timings)))
+
+    for timing, color, name in zip(timings, cycle(colors), all_names):
+        if not timing:
+            continue
+
+        sorted_chunks = sorted(enumerate(timing), key=lambda x: x[1].start)
+
+        offset = timedelta()
+        if common_start:
+            first_start = _apply_tz(sorted_chunks[0][1].start, tz)
+            offset = first_start - datetime(year=1970, month=1, day=1)
+
+        total_size = sum(sum(p.size for p in c.parts) for c in timing) if normalize_y else 1
+        y_value = 0.0
+        x_data = []
+        y_data = []
+        text_data = []
+
+        for idx, chunk in sorted_chunks:
+            chunk_size = sum(p.size for p in chunk.parts)
+            y_value += chunk_size / total_size
+            text = _format_hover(name, idx, chunk, tz)
+            x_data.extend(
+                [_apply_tz(chunk.start, tz) - offset, _apply_tz(chunk.stop, tz) - offset, None]
+            )
+            y_data.extend([y_value, y_value, None])
+            text_data.extend([text] * 3)
+
+        fig.add_trace(
+            go.Scatter(
+                x=x_data,
+                y=y_data,
+                mode="lines",
+                line={"width": line_width, "color": color},
+                text=text_data,
+                hoverinfo="text",
+                name=name,
+            )
+        )
+
+    fig.update_layout(
+        xaxis={"title": "Time", "type": "date"},
+        showlegend=show_legend,
+        legend={"yanchor": "bottom", "y": 0.01, "xanchor": "right", "x": 0.99},
+        margin={"l": 70, "r": 20, "t": 20, "b": 70},
+    )
+
+    if normalize_y:
+        fig.update_yaxes(title="Completed Workload", tickformat=".0%")
+    else:
+        fig.update_yaxes(title="Elements Completed")
+
+    if common_start:
+        fig.update_xaxes(tickformat="%H:%M:%S.%f")
+
+    return fig

--- a/test/unit/test_quantum_program/__init__.py
+++ b/test/unit/test_quantum_program/__init__.py
@@ -1,0 +1,11 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.

--- a/test/unit/test_quantum_program/test_quantum_program.py
+++ b/test/unit/test_quantum_program/test_quantum_program.py
@@ -1,0 +1,137 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import numpy as np
+from qiskit.circuit import Parameter, QuantumCircuit
+from qiskit.quantum_info import PauliLindbladMap
+
+from samplomatic import InjectNoise, Twirl, build
+from samplomatic.quantum_program import QuantumProgram
+
+
+class TestQuantumProgram:
+    """Tests the ``QuantumProgram`` class."""
+
+    def test_quantum_program(self):
+        """Test a quantum program consisting of a circuit item and a samplex item."""
+        shots = 100
+
+        noise_models = [
+            PauliLindbladMap.from_list([("IX", 0.04), ("XX", 0.05)]),
+            PauliLindbladMap.from_list([("XI", 0.02), ("IZ", 0.035)]),
+        ]
+
+        quantum_program = QuantumProgram(
+            shots=shots,
+            noise_maps={f"pl{i}": noise_model for i, noise_model in enumerate(noise_models)},
+        )
+
+        circuit1 = QuantumCircuit(1)
+        circuit1.rx(Parameter("p"), 0)
+
+        circuit_arguments = np.array([[3], [4], [5]])
+        quantum_program.append_circuit_item(
+            circuit1, circuit_arguments=circuit_arguments, chunk_size=6
+        )
+
+        circuit2 = QuantumCircuit(2)
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl0", site="after")]):
+            circuit2.rx(Parameter("p"), 0)
+            circuit2.cx(0, 1)
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1", site="after")]):
+            circuit2.measure_all()
+
+        template_circuit, samplex = build(circuit2)
+        parameter_values = np.array([[[1], [2]], [[3], [4]], [[5], [6]]])
+        quantum_program.append_samplex_item(
+            template_circuit,
+            samplex=samplex,
+            samplex_arguments={"parameter_values": parameter_values},
+            shape=(4, 3, 2),
+            chunk_size=7,
+        )
+
+        new_noise_models = [
+            PauliLindbladMap.from_list([("YI", 0.03), ("IY", 0.01)]),
+            PauliLindbladMap.from_list([("ZI", 0.025), ("XZ", 0.045)]),
+        ]
+        quantum_program.append_samplex_item(
+            template_circuit,
+            samplex=samplex,
+            samplex_arguments={
+                "parameter_values": parameter_values,
+                "pauli_lindblad_maps": {
+                    f"pl{i}": noise_model for i, noise_model in enumerate(new_noise_models)
+                },
+            },
+        )
+
+        assert quantum_program.shots == shots
+
+        circuit_item = quantum_program.items[0]
+        assert circuit_item.circuit == circuit1
+        assert np.array_equal(circuit_item.circuit_arguments, circuit_arguments)
+        assert circuit_item.chunk_size == 6
+        assert circuit_item.shape == (3,)
+
+        samplex_item = quantum_program.items[1]
+        assert samplex_item.samplex == samplex
+        assert samplex_item.circuit == template_circuit
+        assert samplex_item.chunk_size == 7
+        assert samplex_item.shape == (4, 3, 2)
+        assert np.array_equal(samplex_item.samplex_arguments["parameter_values"], parameter_values)
+        for i, noise_model in enumerate(noise_models):
+            assert samplex_item.samplex_arguments[f"pauli_lindblad_maps.pl{i}"] == noise_model
+
+        samplex_item_with_new_noise = quantum_program.items[2]
+        for i, noise_model in enumerate(new_noise_models):
+            assert (
+                samplex_item_with_new_noise.samplex_arguments[f"pauli_lindblad_maps.pl{i}"]
+                == noise_model
+            )
+
+    def test_subset_of_noise_maps(self):
+        """Test handling specific samplex item using only a subset of the program's noise maps.
+
+        Test that `QuantumProgram` knows to handle the case where a specific samplex
+        item uses only a subset of the program's noise maps.
+        """
+        shots = 100
+
+        noise_models = [
+            PauliLindbladMap.from_list([("IX", 0.04), ("XX", 0.05)]),
+            PauliLindbladMap.from_list([("XI", 0.02), ("IZ", 0.035)]),
+        ]
+
+        quantum_program = QuantumProgram(
+            shots=shots,
+            noise_maps={f"pl{i}": noise_model for i, noise_model in enumerate(noise_models)},
+        )
+
+        circuit2 = QuantumCircuit(2)
+        with circuit2.box(annotations=[Twirl(), InjectNoise(ref="pl1", site="after")]):
+            circuit2.measure_all()
+
+        template_circuit, samplex = build(circuit2)
+        quantum_program.append_samplex_item(
+            template_circuit,
+            samplex=samplex,
+            shape=(4, 3, 2),
+            chunk_size=7,
+        )
+
+        samplex_item = quantum_program.items[0]
+        assert samplex_item.samplex == samplex
+        assert samplex_item.circuit == template_circuit
+        assert samplex_item.chunk_size == 7
+        assert samplex_item.shape == (4, 3, 2)
+        assert samplex_item.samplex_arguments["pauli_lindblad_maps.pl1"] == noise_models[1]

--- a/test/unit/test_quantum_program/test_quantum_program_result.py
+++ b/test/unit/test_quantum_program/test_quantum_program_result.py
@@ -1,0 +1,77 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+import numpy as np
+
+from samplomatic.quantum_program import QuantumProgramItemResult, QuantumProgramResult
+
+
+class TestQuantumProgramResult:
+    """Tests the ``QuantumProgramResult`` class."""
+
+    def test_result(self):
+        """Test initializing a ``QuantumProgramResult`` object."""
+        data = [
+            {
+                "alpha": np.random.random((1, 2, 3)).astype(bool),
+                "beta": np.random.random((1, 2, 3)).astype(int),
+            },
+            {"gamma": np.random.random((1, 2, 3)).astype(bool)},
+        ]
+        result = QuantumProgramResult(data=data)
+
+        assert len(result) == 2
+        assert all(isinstance(item, QuantumProgramItemResult) for item in result)
+        assert np.all(result[0]["alpha"] == data[0]["alpha"])
+        assert np.all(result[0]["beta"] == data[0]["beta"])
+        assert np.all(result[1]["gamma"] == data[1]["gamma"])
+
+    def test_metadata(self):
+        """Test the metadata field."""
+        data = [{"alpha": np.random.random((1, 2, 3)).astype(bool)}]
+        metadata = "metadata"
+        result = QuantumProgramResult(data=data, metadata=metadata)
+
+        assert result.metadata == metadata
+
+    def test_passthrough_data(self):
+        """Test the passthrough data field."""
+        data = [{"alpha": np.random.random((1, 2, 3)).astype(bool)}]
+        passthrough_data = {"foo": {"bar": np.random.random((1, 2, 3))}}
+        result = QuantumProgramResult(data=data, passthrough_data=passthrough_data)
+
+        assert result.passthrough_data == passthrough_data
+
+
+class TestQuantumProgramItemResult:
+    """Tests the ``QuantumProgramItemResult`` class."""
+
+    def test_result(self):
+        """Test initializing a ``QuantumProgramItemResult`` object."""
+        result = {
+            "alpha": np.random.random((1, 2, 3)).astype(bool),
+            "beta": np.random.random((1, 2, 3)).astype(int),
+        }
+        item = QuantumProgramItemResult(result)
+
+        assert len(item) == 2
+        assert np.all(item["alpha"] == result["alpha"])
+        assert np.all(item["beta"] == result["beta"])
+
+    def test_metadata(self):
+        """Test initializing a ``QuantumProgramItemResult`` object."""
+        result = {"alpha": np.random.random((1, 2, 3)).astype(bool)}
+        metadata = "metadata"
+        item = QuantumProgramItemResult(result, metadata=metadata)
+
+        assert item.metadata == metadata

--- a/test/unit/test_quantum_program/test_quantum_program_result.py
+++ b/test/unit/test_quantum_program/test_quantum_program_result.py
@@ -11,9 +11,74 @@
 # that they have been altered from the originals.
 
 
+from datetime import datetime, timedelta
+
 import numpy as np
 
-from samplomatic.quantum_program import QuantumProgramItemResult, QuantumProgramResult
+from samplomatic.quantum_program import (
+    ChunkPart,
+    ChunkSpan,
+    ChunkTiming,
+    QuantumProgramItemResult,
+    QuantumProgramResult,
+)
+
+
+def _make_chunk_timings(n: int = 5) -> ChunkTiming:
+    """Create a synthetic ChunkTiming with ``n`` chunks."""
+    t = datetime(year=2025, month=1, day=1)
+    spans = []
+    for i in range(n):
+        start = t + timedelta(seconds=i * 10)
+        stop = start + timedelta(seconds=5 + i)
+        parts = [ChunkPart(idx_item=i % 2, size=10 + i)]
+        spans.append(ChunkSpan(start=start, stop=stop, parts=parts))
+    return ChunkTiming(spans)
+
+
+class TestDrawChunkTiming:
+    """Tests for ``ChunkTiming``."""
+
+    def test_len(self):
+        """Assert ChunkTiming reports the number of spans it contains."""
+        assert len(_make_chunk_timings()) == 5
+
+    def test_getitem_int(self):
+        """Assert integer indexing returns a ChunkSpan."""
+        item = _make_chunk_timings()[0]
+        assert isinstance(item, ChunkSpan)
+
+    def test_getitem_slice(self):
+        """Assert slice indexing returns a new ChunkTiming with the selected spans."""
+        sliced = _make_chunk_timings()[1:3]
+        assert isinstance(sliced, ChunkTiming)
+        assert len(sliced) == 2
+
+    def test_iter(self):
+        """Assert iteration yields all ChunkSpan objects."""
+        items = list(_make_chunk_timings())
+        assert len(items) == 5
+        assert all(isinstance(s, ChunkSpan) for s in items)
+
+    def test_eq(self):
+        """Assert two ChunkTiming built from the same spans compare equal."""
+        other = _make_chunk_timings()
+        assert _make_chunk_timings() == other
+
+    def test_repr(self):
+        """Assert repr includes the class name."""
+        assert "ChunkTiming" in repr(_make_chunk_timings())
+
+    def test_start_stop_duration(self):
+        """Assert start and stop are datetimes and duration is positive."""
+        assert isinstance(_make_chunk_timings().start, datetime)
+        assert isinstance(_make_chunk_timings().stop, datetime)
+        assert _make_chunk_timings().duration > 0
+
+    def test_draw(self):
+        """Test the draw method."""
+        timings = _make_chunk_timings()
+        timings.draw()
 
 
 class TestQuantumProgramResult:

--- a/test/unit/test_quantum_program/test_quantum_program_result.py
+++ b/test/unit/test_quantum_program/test_quantum_program_result.py
@@ -10,10 +10,10 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-
 from datetime import datetime, timedelta
 
 import numpy as np
+import pytest
 
 from samplomatic.quantum_program import (
     ChunkPart,
@@ -101,13 +101,13 @@ class TestQuantumProgramResult:
         assert np.all(result[0]["beta"] == data[0]["beta"])
         assert np.all(result[1]["gamma"] == data[1]["gamma"])
 
-    def test_metadata(self):
-        """Test the metadata field."""
+    def test_timing(self):
+        """Test the ``timing`` property."""
         data = [{"alpha": np.random.random((1, 2, 3)).astype(bool)}]
-        metadata = "metadata"
-        result = QuantumProgramResult(data=data, metadata=metadata)
+        result = QuantumProgramResult(data=data)
 
-        assert result.metadata == metadata
+        with pytest.raises(NotImplementedError):
+            result.timing
 
     def test_passthrough_data(self):
         """Test the passthrough data field."""
@@ -132,11 +132,3 @@ class TestQuantumProgramItemResult:
         assert len(item) == 2
         assert np.all(item["alpha"] == result["alpha"])
         assert np.all(item["beta"] == result["beta"])
-
-    def test_metadata(self):
-        """Test initializing a ``QuantumProgramItemResult`` object."""
-        result = {"alpha": np.random.random((1, 2, 3)).astype(bool)}
-        metadata = "metadata"
-        item = QuantumProgramItemResult(result, metadata=metadata)
-
-        assert item.metadata == metadata

--- a/test/unit/test_visualization/test_draw_chunk_timings.py
+++ b/test/unit/test_visualization/test_draw_chunk_timings.py
@@ -16,12 +16,11 @@ from datetime import datetime, timedelta
 
 import pytest
 
+from samplomatic.optionals import HAS_PLOTLY
 from samplomatic.quantum_program import (
     ChunkPart,
     ChunkSpan,
     ChunkTiming,
-    Metadata,
-    QuantumProgramResult,
 )
 from samplomatic.visualization.draw_chunk_timings import draw_chunk_timings
 
@@ -38,25 +37,30 @@ def _make_chunk_timings(n: int = 5) -> ChunkTiming:
     return ChunkTiming(spans)
 
 
+@pytest.mark.skipif(not HAS_PLOTLY, reason="plotly is not installed")
 class TestDrawChunkTiming:
     """Tests for ``draw_chunk_timings``."""
 
     @pytest.mark.parametrize("normalize_y", [True, False])
-    def test_draw_normalize_y(self, normalize_y):
+    def test_draw_normalize_y(self, normalize_y, save_plot):
         """Verify draw_chunk_timings renders without error with normalize_y on and off."""
-        draw_chunk_timings(_make_chunk_timings(), normalize_y=normalize_y)
+        plot = draw_chunk_timings(_make_chunk_timings(), normalize_y=normalize_y)
+        save_plot(plot)
 
-    def test_draw_common_start(self):
+    def test_draw_common_start(self, save_plot):
         """Verify draw_chunk_timings renders without error when common_start=True."""
-        draw_chunk_timings(_make_chunk_timings(), common_start=True)
+        plot = draw_chunk_timings(_make_chunk_timings(), common_start=True)
+        save_plot(plot)
 
-    def test_draw_with_name(self):
+    def test_draw_with_name(self, save_plot):
         """Verify draw_chunk_timings renders without error when a name is provided."""
-        draw_chunk_timings(_make_chunk_timings(), names="my_job")
+        plot = draw_chunk_timings(_make_chunk_timings(), names="my_job")
+        save_plot(plot)
 
-    def test_draw_empty(self):
+    def test_draw_empty(self, save_plot):
         """Verify draw_chunk_timings handles an empty ChunkTiming without error."""
-        draw_chunk_timings(ChunkTiming([]))
+        plot = draw_chunk_timings(ChunkTiming([]))
+        save_plot(plot)
 
     @pytest.mark.parametrize(
         ["normalize_y", "common_start", "width", "names"],
@@ -66,10 +70,10 @@ class TestDrawChunkTiming:
             (True, False, 4, ["alpha", "beta"]),
         ],
     )
-    def test_two_chunk_timings(self, normalize_y, common_start, width, names):
+    def test_two_chunk_timings(self, normalize_y, common_start, width, names, save_plot):
         """Verify draw_chunk_timings renders two ChunkTiming for cross-job comparison."""
         ct2 = _make_chunk_timings(n=3)
-        draw_chunk_timings(
+        plot = draw_chunk_timings(
             _make_chunk_timings(),
             ct2,
             normalize_y=normalize_y,
@@ -77,24 +81,14 @@ class TestDrawChunkTiming:
             line_width=width,
             names=names,
         )
+        save_plot(plot)
 
-    def test_draw_method(self):
+    def test_draw_method(self, save_plot):
         """Verify ChunkTiming.draw() renders without error."""
-        _make_chunk_timings().draw()
+        plot = _make_chunk_timings().draw()
+        save_plot(plot)
 
-    def test_draw_method_normalize_y(self):
+    def test_draw_method_normalize_y(self, save_plot):
         """Verify ChunkTiming.draw() renders without error when normalize_y=True."""
-        _make_chunk_timings().draw(normalize_y=True)
-
-    def test_result_chunk_timings_property(self):
-        """Assert QuantumProgramResult.chunk_timings wraps the metadata spans."""
-        metadata = Metadata(chunk_timing=list(_make_chunk_timings()))
-        result = QuantumProgramResult(data=[], metadata=metadata)
-        assert isinstance(result.timing, ChunkTiming)
-        assert len(result.timing) == len(_make_chunk_timings())
-
-    def test_result_chunk_timings_empty(self):
-        """Assert QuantumProgramResult.chunk_timings is empty when no metadata spans are present."""
-        result = QuantumProgramResult(data=[])
-        assert isinstance(result.timing, ChunkTiming)
-        assert len(result.timing) == 0
+        plot = _make_chunk_timings().draw(normalize_y=True)
+        save_plot(plot)

--- a/test/unit/test_visualization/test_draw_chunk_timings.py
+++ b/test/unit/test_visualization/test_draw_chunk_timings.py
@@ -1,0 +1,100 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Unit tests for draw_chunk_timings."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from samplomatic.quantum_program import (
+    ChunkPart,
+    ChunkSpan,
+    ChunkTiming,
+    Metadata,
+    QuantumProgramResult,
+)
+from samplomatic.visualization.draw_chunk_timings import draw_chunk_timings
+
+
+def _make_chunk_timings(n: int = 5) -> ChunkTiming:
+    """Create a synthetic ChunkTiming with ``n`` chunks."""
+    t = datetime(year=2025, month=1, day=1)
+    spans = []
+    for i in range(n):
+        start = t + timedelta(seconds=i * 10)
+        stop = start + timedelta(seconds=5 + i)
+        parts = [ChunkPart(idx_item=i % 2, size=10 + i)]
+        spans.append(ChunkSpan(start=start, stop=stop, parts=parts))
+    return ChunkTiming(spans)
+
+
+class TestDrawChunkTiming:
+    """Tests for ``draw_chunk_timings``."""
+
+    @pytest.mark.parametrize("normalize_y", [True, False])
+    def test_draw_normalize_y(self, normalize_y):
+        """Verify draw_chunk_timings renders without error with normalize_y on and off."""
+        draw_chunk_timings(_make_chunk_timings(), normalize_y=normalize_y)
+
+    def test_draw_common_start(self):
+        """Verify draw_chunk_timings renders without error when common_start=True."""
+        draw_chunk_timings(_make_chunk_timings(), common_start=True)
+
+    def test_draw_with_name(self):
+        """Verify draw_chunk_timings renders without error when a name is provided."""
+        draw_chunk_timings(_make_chunk_timings(), names="my_job")
+
+    def test_draw_empty(self):
+        """Verify draw_chunk_timings handles an empty ChunkTiming without error."""
+        draw_chunk_timings(ChunkTiming([]))
+
+    @pytest.mark.parametrize(
+        ["normalize_y", "common_start", "width", "names"],
+        [
+            (False, False, 4, None),
+            (True, True, 8, "alpha"),
+            (True, False, 4, ["alpha", "beta"]),
+        ],
+    )
+    def test_two_chunk_timings(self, normalize_y, common_start, width, names):
+        """Verify draw_chunk_timings renders two ChunkTiming for cross-job comparison."""
+        ct2 = _make_chunk_timings(n=3)
+        draw_chunk_timings(
+            _make_chunk_timings(),
+            ct2,
+            normalize_y=normalize_y,
+            common_start=common_start,
+            line_width=width,
+            names=names,
+        )
+
+    def test_draw_method(self):
+        """Verify ChunkTiming.draw() renders without error."""
+        _make_chunk_timings().draw()
+
+    def test_draw_method_normalize_y(self):
+        """Verify ChunkTiming.draw() renders without error when normalize_y=True."""
+        _make_chunk_timings().draw(normalize_y=True)
+
+    def test_result_chunk_timings_property(self):
+        """Assert QuantumProgramResult.chunk_timings wraps the metadata spans."""
+        metadata = Metadata(chunk_timing=list(_make_chunk_timings()))
+        result = QuantumProgramResult(data=[], metadata=metadata)
+        assert isinstance(result.timing, ChunkTiming)
+        assert len(result.timing) == len(_make_chunk_timings())
+
+    def test_result_chunk_timings_empty(self):
+        """Assert QuantumProgramResult.chunk_timings is empty when no metadata spans are present."""
+        result = QuantumProgramResult(data=[])
+        assert isinstance(result.timing, ChunkTiming)
+        assert len(result.timing) == 0


### PR DESCRIPTION
## Summary

This PR:
- Adds a version of `QuantumProgram` and related classes copy-pasted from qiskit-ibm-runtime
- Adds all the tests currently present for those classes
- Improves the description `samplomatic/quantum_program/__init__.py`
- Adds the module to the public documentation

Closes #395 