### PR TITLE
Add support for named measurements, such as `"measure_2"`

### DIFF
--- a/changelog.d/399.fixed.md
+++ b/changelog.d/399.fixed.md
@@ -1,1 +1,1 @@
-When the boxing pass manager encounters an instruction whose name starts with `"measure"`, it treats it as a standard measurement instruction.
+When the boxing pass manager encounters an instruction whose name starts with `"meas"`, it treats it as a standard measurement instruction.

--- a/changelog.d/399.fixed.md
+++ b/changelog.d/399.fixed.md
@@ -1,0 +1,1 @@
+When the boxing pass manager encounters an instruction whose name starts with `"measure"`, it treats it as a standard measurement instruction.

--- a/samplomatic/transpiler/passes/add_terminal_right_dressed_boxes.py
+++ b/samplomatic/transpiler/passes/add_terminal_right_dressed_boxes.py
@@ -135,7 +135,7 @@ class AddTerminalRightDressedBoxes(TransformationPass):
                 measured_qubits = set()
                 qubit_map = None  # don't compute this unless necessary
                 for instr in node.op.body:
-                    if instr.operation.name.startswith("measure"):
+                    if instr.operation.name.startswith("meas"):
                         qubit_map = qubit_map or (qubit_map := _inverse_box_qubit_map(node))
                         measured_qubits.update(qubit_map[qubit] for qubit in instr.qubits)
 

--- a/samplomatic/transpiler/passes/add_terminal_right_dressed_boxes.py
+++ b/samplomatic/transpiler/passes/add_terminal_right_dressed_boxes.py
@@ -135,7 +135,7 @@ class AddTerminalRightDressedBoxes(TransformationPass):
                 measured_qubits = set()
                 qubit_map = None  # don't compute this unless necessary
                 for instr in node.op.body:
-                    if instr.operation.name == "measure":
+                    if instr.operation.name.startswith("measure"):
                         qubit_map = qubit_map or (qubit_map := _inverse_box_qubit_map(node))
                         measured_qubits.update(qubit_map[qubit] for qubit in instr.qubits)
 

--- a/samplomatic/transpiler/passes/group_gates_into_boxes.py
+++ b/samplomatic/transpiler/passes/group_gates_into_boxes.py
@@ -116,7 +116,7 @@ class GroupGatesIntoBoxes(TransformationPass):
                 # Flush: push the boundary one step further in the traversal direction
                 for qubit in node.qargs:
                     group_indices[qubit] = group_idx + direction
-            elif name.startswith("measure"):
+            elif name.startswith("meas"):
                 # Flush the single-qubit gate nodes without placing them in a group
                 qubit = node.qargs[0]
                 clbit = node.cargs[0]

--- a/samplomatic/transpiler/passes/group_gates_into_boxes.py
+++ b/samplomatic/transpiler/passes/group_gates_into_boxes.py
@@ -116,7 +116,7 @@ class GroupGatesIntoBoxes(TransformationPass):
                 # Flush: push the boundary one step further in the traversal direction
                 for qubit in node.qargs:
                     group_indices[qubit] = group_idx + direction
-            elif name == "measure":
+            elif name.startswith("measure"):
                 # Flush the single-qubit gate nodes without placing them in a group
                 qubit = node.qargs[0]
                 clbit = node.cargs[0]

--- a/samplomatic/transpiler/passes/group_meas_into_boxes.py
+++ b/samplomatic/transpiler/passes/group_meas_into_boxes.py
@@ -121,7 +121,7 @@ class GroupMeasIntoBoxes(TransformationPass):
                 # Update the trackers
                 for bit in node.qargs + node.cargs:
                     group_indices[bit] = group_idx
-            elif name == "measure":
+            elif name.startswith("measure"):
                 # Add this measurement to the group
                 groups[group_idx].append(node)
 

--- a/samplomatic/transpiler/passes/group_meas_into_boxes.py
+++ b/samplomatic/transpiler/passes/group_meas_into_boxes.py
@@ -121,7 +121,7 @@ class GroupMeasIntoBoxes(TransformationPass):
                 # Update the trackers
                 for bit in node.qargs + node.cargs:
                     group_indices[bit] = group_idx
-            elif name.startswith("measure"):
+            elif name.startswith("meas"):
                 # Add this measurement to the group
                 groups[group_idx].append(node)
 

--- a/samplomatic/transpiler/passes/utils.py
+++ b/samplomatic/transpiler/passes/utils.py
@@ -102,7 +102,7 @@ def validate_op_is_supported(node: DAGOpNode):
     """
     if (
         node.is_standard_gate()
-        or node.op.name.startswith("measure")
+        or node.op.name.startswith("meas")
         or node.op.name in ["box", "barrier", "reset", "delay"]
     ):
         return

--- a/samplomatic/transpiler/passes/utils.py
+++ b/samplomatic/transpiler/passes/utils.py
@@ -100,6 +100,10 @@ def validate_op_is_supported(node: DAGOpNode):
         TranspilerError: If node contains anything other than a box, a barrier, a measurement, or
         a gate.
     """
-    if node.is_standard_gate() or node.op.name in ["box", "barrier", "measure", "reset", "delay"]:
+    if (
+        node.is_standard_gate()
+        or node.op.name.startswith("measure")
+        or node.op.name in ["box", "barrier", "reset", "delay"]
+    ):
         return
     raise TranspilerError(f"``'{node.op.name}'`` is not supported.")

--- a/samplomatic/utils/box_key.py
+++ b/samplomatic/utils/box_key.py
@@ -89,7 +89,11 @@ class BoxKey:
         """
         op = node.op
 
-        if not (node.is_standard_gate() or op.name in ["barrier", "measure", "delay"]):
+        if not (
+            node.is_standard_gate()
+            or op.name.startswith("measure")
+            or op.name in ["barrier", "delay"]
+        ):
             raise ValueError(f"Hashing of {op.name} is not supported.")
 
         op_hashable = (op.name, op.num_qubits, op.num_clbits)

--- a/samplomatic/utils/box_key.py
+++ b/samplomatic/utils/box_key.py
@@ -90,9 +90,7 @@ class BoxKey:
         op = node.op
 
         if not (
-            node.is_standard_gate()
-            or op.name.startswith("measure")
-            or op.name in ["barrier", "delay"]
+            node.is_standard_gate() or op.name.startswith("meas") or op.name in ["barrier", "delay"]
         ):
             raise ValueError(f"Hashing of {op.name} is not supported.")
 

--- a/test/unit/test_transpiler/test_passes/test_add_terminal_right_dressed_boxes.py
+++ b/test/unit/test_transpiler/test_passes/test_add_terminal_right_dressed_boxes.py
@@ -21,6 +21,8 @@ from qiskit.transpiler.exceptions import TranspilerError
 from samplomatic.annotations import DecompositionMode, GroupMode, Twirl
 from samplomatic.transpiler.passes import AddTerminalRightDressedBoxes
 
+from .utils import NamedMeasure
+
 
 def make_circuits():
     theta = Parameter("theta")
@@ -238,6 +240,22 @@ def make_circuits():
         expected_circuit.noop([0, 1, 2, 3])
 
     yield (circuit, expected_circuit, "circuit_ghz_with_delay")
+
+    circuit = QuantumCircuit(1, 2)
+    with circuit.box([Twirl()]):
+        circuit.x(0)
+    circuit.append(NamedMeasure("measure_2"), [0], [0])
+    circuit.append(NamedMeasure("measure_2"), [0], [1])
+
+    expected_circuit = QuantumCircuit(1, 2)
+    with expected_circuit.box([Twirl()]):
+        expected_circuit.x(0)
+    with expected_circuit.box([Twirl(dressing="right")]):
+        expected_circuit.noop(0)
+    expected_circuit.append(NamedMeasure("measure_2"), [0], [0])
+    expected_circuit.append(NamedMeasure("measure_2"), [0], [1])
+
+    yield circuit, expected_circuit, "circuit_with_measure_2"
 
 
 def pytest_generate_tests(metafunc):

--- a/test/unit/test_transpiler/test_passes/test_group_gates_into_boxes.py
+++ b/test/unit/test_transpiler/test_passes/test_group_gates_into_boxes.py
@@ -21,6 +21,8 @@ from qiskit.transpiler.exceptions import TranspilerError
 from samplomatic.annotations import Twirl
 from samplomatic.transpiler.passes import GroupGatesIntoBoxes
 
+from .utils import NamedMeasure
+
 
 def make_circuits():
     theta = Parameter("theta")
@@ -228,7 +230,7 @@ def make_circuits():
     circuit.cx(0, 1)
     circuit.x(0)
     circuit.t(1)
-    circuit.measure(1, 0)
+    circuit.append(NamedMeasure("measure_2"), [1], [0])
     circuit.measure(2, 0)
     circuit.cx(2, 3)
     circuit.barrier()
@@ -242,7 +244,7 @@ def make_circuits():
         expected_circuit.cx(0, 1)
     expected_circuit.x(0)
     expected_circuit.t(1)
-    expected_circuit.measure(1, 0)
+    expected_circuit.append(NamedMeasure("measure_2"), [1], [0])
     expected_circuit.measure(2, 0)
     with expected_circuit.box([Twirl(dressing="left")]):
         expected_circuit.cx(2, 3)

--- a/test/unit/test_transpiler/test_passes/utils.py
+++ b/test/unit/test_transpiler/test_passes/utils.py
@@ -27,7 +27,7 @@ class NamedMeasure(Instruction):
         if not name.startswith("measure_"):
             raise ValueError(
                 "Invalid name for mid-circuit measure instruction. "
-                "The provided name must start with `measure_`"
+                "The provided name must start with `measure_`."
             )
 
         super().__init__(name, 1, 1, [], label=label)

--- a/test/unit/test_transpiler/test_passes/utils.py
+++ b/test/unit/test_transpiler/test_passes/utils.py
@@ -16,7 +16,7 @@ from qiskit.circuit import Instruction
 
 
 class NamedMeasure(Instruction):
-    """Alternative 'named' measurement definition.
+    """Alternative named measurement definition.
 
     This instruction implements an alternative 'named' measurement definition
     (one classical bit, one quantum bit), whose name can be used to map to a corresponding

--- a/test/unit/test_transpiler/test_passes/utils.py
+++ b/test/unit/test_transpiler/test_passes/utils.py
@@ -1,0 +1,33 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Utilities for testing transpiler passes."""
+
+from qiskit.circuit import Instruction
+
+
+class NamedMeasure(Instruction):
+    """Alternative 'named' measurement definition.
+
+    This instruction implements an alternative 'named' measurement definition
+    (one classical bit, one quantum bit), whose name can be used to map to a corresponding
+    mid-circuit measurement instruction implementation on hardware.
+    """
+
+    def __init__(self, name: str = "measure_2", label: str | None = None) -> None:
+        if not name.startswith("measure_"):
+            raise ValueError(
+                "Invalid name for mid-circuit measure instruction. "
+                "The provided name must start with `measure_`"
+            )
+
+        super().__init__(name, 1, 1, [], label=label)

--- a/test/unit/test_transpiler/test_passes/utils.py
+++ b/test/unit/test_transpiler/test_passes/utils.py
@@ -18,7 +18,7 @@ from qiskit.circuit import Instruction
 class NamedMeasure(Instruction):
     """Alternative named measurement definition.
 
-    This instruction implements an alternative 'named' measurement definition
+    This instruction implements an alternative named measurement definition
     (one classical bit, one quantum bit), whose name can be used to map to a corresponding
     mid-circuit measurement instruction implementation on hardware.
     """


### PR DESCRIPTION
## Summary
Fixes: #398
