### PR TITLE
Remove subsystem restrictions on `local_pauli`

### DIFF
--- a/changelog.d/401.improved.md
+++ b/changelog.d/401.improved.md
@@ -1,1 +1,2 @@
 Removed restrictions on twirling Clifford two-qubit gates on overlapping subsystems with `GroupMode.local_pauli` group mode.
+Further, fractional gates twirled with `GroupMode.local_pauli` at Clifford angles are now twirled with `GroupMode.pauli`.

--- a/changelog.d/401.improved.md
+++ b/changelog.d/401.improved.md
@@ -1,0 +1,1 @@
+Removed restrictions on twirling Clifford two-qubit gates on overlapping subsystems with `GroupMode.local_pauli` group mode.

--- a/samplomatic/builders/get_builder.py
+++ b/samplomatic/builders/get_builder.py
@@ -39,6 +39,14 @@ from .passthrough_builder import PassthroughBuilder
 from .specs import CollectionSpec, EmissionSpec
 
 
+def _classify_node_local_pauli(node) -> bool:
+    return node.op.name in SUPPORTED_2Q_FRACTIONAL_GATES
+
+
+def _classify_node_local_clifford(_) -> bool:
+    return True
+
+
 def _classify_gate_dependent_twirl(body, emission: EmissionSpec) -> None:
     """Classify qubits in a gate-dependent twirl box into entangling and fallback qubits.
 
@@ -52,22 +60,26 @@ def _classify_gate_dependent_twirl(body, emission: EmissionSpec) -> None:
         BuildError: If multiple distinct 2Q gate types are used.
     """
     dag = circuit_to_dag(body)
-    seen_pairs = QubitPartition(2, [])
+    seen_qubits = set()
     gate_pairs: dict[str, QubitPartition] = {}
+
+    classify_node = (
+        _classify_node_local_pauli
+        if emission.twirl_type == GroupMode.LOCAL_PAULI
+        else _classify_node_local_clifford
+    )
 
     for node in dag.topological_op_nodes():
         if node.is_standard_gate() and node.op.num_qubits == 2:
             pair = tuple(node.qargs)
-            if pair in seen_pairs:
+            if seen_qubits.intersection(pair):
                 raise BuildError(
-                    f"Cannot use gate-dependent twirling with duplicate 2Q gates on qubits {pair}."
+                    "Cannot use gate-dependent twirling with duplicate two-qubit gates on qubits "
+                    f"{pair}."
                 )
-            # QubitPartition.add rejects partial overlaps automatically
-            gate_pairs.setdefault(node.op.name, QubitPartition(2, [])).add(pair)
-            seen_pairs.add(pair)
-
-    if emission.twirl_type == GroupMode.LOCAL_PAULI:
-        gate_pairs = {k: v for k, v in gate_pairs.items() if k in SUPPORTED_2Q_FRACTIONAL_GATES}
+            if classify_node(node):
+                seen_qubits.update(pair)
+                gate_pairs.setdefault(node.op.name, QubitPartition(2, [])).add(pair)
 
     if not gate_pairs:
         emission.twirl_type = GroupMode.PAULI

--- a/samplomatic/builders/get_builder.py
+++ b/samplomatic/builders/get_builder.py
@@ -55,9 +55,9 @@ def _classify_gate_dependent_twirl(body, emission: EmissionSpec) -> None:
     and ``twirl_gate``. If no two-qubit gates are found, sets ``twirl_type`` to PAULI.
 
     Raises:
-        BuildError: If the same qubit pair has duplicate 2Q gates.
-        BuildError: If 2Q gates on partially overlapping qubits are found.
-        BuildError: If multiple distinct 2Q gate types are used.
+        BuildError: If the same qubit pair has duplicate two-qubits gates.
+        BuildError: If two-qubits gates on partially overlapping qubits are found.
+        BuildError: If multiple distinct two-qubits gate types are used.
     """
     dag = circuit_to_dag(body)
     seen_qubits = set()

--- a/samplomatic/builders/get_builder.py
+++ b/samplomatic/builders/get_builder.py
@@ -14,6 +14,7 @@
 
 from collections.abc import Callable, Sequence
 
+import numpy as np
 from qiskit.circuit import Annotation, Qubit
 from qiskit.converters import circuit_to_dag
 
@@ -39,12 +40,54 @@ from .passthrough_builder import PassthroughBuilder
 from .specs import CollectionSpec, EmissionSpec
 
 
-def _classify_node_local_pauli(node) -> bool:
-    return node.op.name in SUPPORTED_2Q_FRACTIONAL_GATES
+def _local_pauli_twirls(dag) -> tuple[dict[str, QubitPartition], set[Qubit]]:
+    seen_qubits = set()
+    other_qubits = set()
+    gate_pairs: dict[str, QubitPartition] = {}
+
+    for node in dag.topological_op_nodes():
+        if node.is_standard_gate() and node.op.num_qubits == 2:
+            pair = tuple(node.qargs)
+            if node.op.name in SUPPORTED_2Q_FRACTIONAL_GATES and not (
+                not node.op.is_parameterized() and np.allclose(np.abs(node.op.params), np.pi / 2)
+            ):
+                if seen_qubits.intersection(pair):
+                    raise BuildError(
+                        f"Cannot use `{GroupMode.LOCAL_PAULI}` twirling on a box with multiple "
+                        f"two-qubit gates from `{SUPPORTED_2Q_FRACTIONAL_GATES}` on one of qubits "
+                        f"{pair}."
+                    )
+                gate_pairs.setdefault(node.op.name, QubitPartition(2, [])).add(pair)
+                seen_qubits.update(pair)
+            else:
+                other_qubits.update(pair)
+
+    if seen_qubits.intersection(other_qubits):
+        raise BuildError(
+            f"Cannot use `{GroupMode.LOCAL_PAULI}` twirling on a box where gates from "
+            f"`{SUPPORTED_2Q_FRACTIONAL_GATES}` have overlapping support with other "
+            "entanglers."
+        )
+
+    return gate_pairs, seen_qubits
 
 
-def _classify_node_local_clifford(_) -> bool:
-    return True
+def _local_c1_twirls(dag) -> tuple[dict[str, QubitPartition], set[Qubit]]:
+    seen_qubits = set()
+    gate_pairs: dict[str, QubitPartition] = {}
+
+    for node in dag.topological_op_nodes():
+        if node.is_standard_gate() and node.op.num_qubits == 2:
+            pair = tuple(node.qargs)
+            if seen_qubits.intersection(pair):
+                raise BuildError(
+                    f"Cannot use `{GroupMode.LOCAL_C1}` twirling with multiple two-qubit gates on "
+                    f"one of qubits {pair}."
+                )
+            seen_qubits.update(pair)
+            gate_pairs.setdefault(node.op.name, QubitPartition(2, [])).add(pair)
+
+    return gate_pairs, seen_qubits
 
 
 def _classify_gate_dependent_twirl(body, emission: EmissionSpec) -> None:
@@ -55,46 +98,26 @@ def _classify_gate_dependent_twirl(body, emission: EmissionSpec) -> None:
     and ``twirl_gate``. If no two-qubit gates are found, sets ``twirl_type`` to PAULI.
 
     Raises:
-        BuildError: If the same qubit pair has duplicate two-qubits gates.
-        BuildError: If two-qubits gates on partially overlapping qubits are found.
-        BuildError: If multiple distinct two-qubits gate types are used.
+        BuildError: If the same qubit pair has duplicate gate-dependent two-qubits gates.
+        BuildError: If gate-dependent two-qubits gates on partially overlapping qubits are found.
     """
     dag = circuit_to_dag(body)
-    seen_qubits = set()
-    gate_pairs: dict[str, QubitPartition] = {}
-
-    classify_node = (
-        _classify_node_local_pauli
-        if emission.twirl_type == GroupMode.LOCAL_PAULI
-        else _classify_node_local_clifford
+    local_twirls = (
+        _local_pauli_twirls if emission.twirl_type is GroupMode.LOCAL_PAULI else _local_c1_twirls
     )
-
-    for node in dag.topological_op_nodes():
-        if node.is_standard_gate() and node.op.num_qubits == 2:
-            pair = tuple(node.qargs)
-            if seen_qubits.intersection(pair):
-                raise BuildError(
-                    "Cannot use gate-dependent twirling with duplicate two-qubit gates on qubits "
-                    f"{pair}."
-                )
-            if classify_node(node):
-                seen_qubits.update(pair)
-                gate_pairs.setdefault(node.op.name, QubitPartition(2, [])).add(pair)
+    gate_pairs, seen_qubits = local_twirls(dag)
 
     if not gate_pairs:
         emission.twirl_type = GroupMode.PAULI
         return
 
     gate_dependent_twirls = {}
-    seen_qubits = set()
     for gate, pairs in gate_pairs.items():
         # Gate-dependent qubits: flatten pairs preserving operand order
         gate_dependent_qubit_list = []
         for pair in pairs:
             for q in pair:
-                if q not in seen_qubits:
-                    seen_qubits.add(q)
-                    gate_dependent_qubit_list.append((q,))
+                gate_dependent_qubit_list.append((q,))
         gate_dependent_twirls[gate] = QubitPartition(1, gate_dependent_qubit_list)
 
     emission.gate_dependent_twirls = gate_dependent_twirls

--- a/test/integration/test_static_twirling_samples.py
+++ b/test/integration/test_static_twirling_samples.py
@@ -465,6 +465,20 @@ def make_circuits():
 
     yield circuit, "rzz_non_clifford_bound_angle_and_cz"
 
+    circuit = QuantumCircuit(5)
+    with circuit.box([Twirl("local_pauli")]):
+        circuit.rzz(np.pi / 4, 0, 1)
+        circuit.cz(2, 3)
+        circuit.cz(3, 4)
+
+    with circuit.box([Twirl("phase", dressing="right")]):
+        circuit.noop(range(2))
+
+    with circuit.box([Twirl("pauli", dressing="right")]):
+        circuit.noop(range(2, 5))
+
+    yield circuit, "rzz_non_clifford_bound_angle_and_cz_overlap"
+
 
 def pytest_generate_tests(metafunc):
     if "circuit" in metafunc.fixturenames:

--- a/test/unit/test_builders/test_gate_dependent_twirl_building.py
+++ b/test/unit/test_builders/test_gate_dependent_twirl_building.py
@@ -12,6 +12,7 @@
 
 """Test gate-dependent twirl buidling."""
 
+import numpy as np
 import pytest
 from qiskit.circuit import Parameter, QuantumCircuit
 
@@ -23,7 +24,7 @@ from samplomatic.pre_samplex import PreEmit
 
 class TestGateDependetTwirling:
     def test_multiple_2q_gates_local_c1(self):
-        """Test left-dressed local_c1 box has multiple 2Q gate emissions."""
+        """Test left-dressed local_c1 box has multiple two-qubit gate emissions."""
         circuit = QuantumCircuit(4)
         with circuit.box([Twirl(group="local_c1", dressing="left")]):
             circuit.cx(0, 1)
@@ -41,7 +42,7 @@ class TestGateDependetTwirling:
         assert any(n.twirl_gate is None and n.register_type == "pauli" for n in pre_emits)
 
     def test_multiple_2q_gate_local_pauli(self):
-        """Test left-dressed local_pauli box has multiple 2Q gate emissions."""
+        """Test left-dressed local_pauli box has multiple two-qubit gate emissions."""
         circuit = QuantumCircuit(4)
         with circuit.box([Twirl(group="local_pauli", dressing="left")]):
             circuit.rzz(Parameter("a"), 0, 1)
@@ -55,6 +56,50 @@ class TestGateDependetTwirling:
         assert any(n.twirl_gate == "rzz" and n.register_type == "local_pauli" for n in pre_emits)
         assert any(n.twirl_gate is None and n.register_type == "pauli" for n in pre_emits)
 
+    def test_overlapping_rzzs_local_pauli(self):
+        """Error when a local_pauli box has overlapping RZZs."""
+        circuit = QuantumCircuit(3)
+        with circuit.box([Twirl(group="local_pauli", dressing="left")]):
+            circuit.rzz(Parameter("a"), 0, 1)
+            circuit.rzz(Parameter("b"), 1, 2)
+            circuit.measure_all()
+
+        with pytest.raises(BuildError, match="with multiple two-qubit gates from"):
+            pre_build(circuit)
+
+    def test_overlapping_gates_local_pauli(self):
+        """Error when a local_pauli box has overlapping RZZ with another entangler."""
+        circuit = QuantumCircuit(3)
+        with circuit.box([Twirl(group="local_pauli", dressing="left")]):
+            circuit.rzz(Parameter("a"), 0, 1)
+            circuit.cz(1, 2)
+            circuit.measure_all()
+
+        with pytest.raises(BuildError, match="other entanglers"):
+            pre_build(circuit)
+
+        circuit = QuantumCircuit(3)
+        with circuit.box([Twirl(group="local_pauli", dressing="left")]):
+            circuit.cz(1, 2)
+            circuit.rzz(Parameter("a"), 0, 1)
+            circuit.measure_all()
+
+        with pytest.raises(BuildError, match="other entanglers"):
+            pre_build(circuit)
+
+    def test_2q_gate_local_pauli_clifford_angle(self):
+        """Test local_pauli falls back to pauli for fractional gates at Clifford angles."""
+        circuit = QuantumCircuit(4)
+        with circuit.box([Twirl(group="local_pauli", dressing="left")]):
+            circuit.rzz(np.pi / 2, 0, 1)
+            circuit.measure_all()
+
+        _, pre_samplex = pre_build(circuit)
+        pre_emits = [node for node in pre_samplex.graph.nodes() if isinstance(node, PreEmit)]
+
+        assert len(pre_emits) == 1
+        assert any(n.twirl_gate is None and n.register_type == "pauli" for n in pre_emits)
+
     def test_overlapping_2q_gates_same_pair(self):
         """Error when a local_c1 box has duplicate two-qubit gates on the same qubits."""
         circuit = QuantumCircuit(2)
@@ -66,7 +111,7 @@ class TestGateDependetTwirling:
         with circuit.box([Twirl(dressing="right")]):
             circuit.noop(0, 1)
 
-        with pytest.raises(BuildError, match="duplicate two-qubit gates"):
+        with pytest.raises(BuildError, match="Cannot use `GroupMode.LOCAL_C1`"):
             pre_build(circuit)
 
     def test_overlapping_2q_gates_different_pairs(self):
@@ -79,7 +124,7 @@ class TestGateDependetTwirling:
         with circuit.box([Twirl(dressing="right")]):
             circuit.noop(0, 1, 2)
 
-        with pytest.raises(BuildError, match="duplicate two-qubit gates"):
+        with pytest.raises(BuildError, match="Cannot use `GroupMode.LOCAL_C1`"):
             pre_build(circuit)
 
     def test_measurement_with_c1_twirl(self):

--- a/test/unit/test_builders/test_gate_dependent_twirl_building.py
+++ b/test/unit/test_builders/test_gate_dependent_twirl_building.py
@@ -79,7 +79,7 @@ class TestGateDependetTwirling:
         with circuit.box([Twirl(dressing="right")]):
             circuit.noop(0, 1, 2)
 
-        with pytest.raises(BuildError, match="overlapping"):
+        with pytest.raises(BuildError, match="duplicate 2Q gates"):
             pre_build(circuit)
 
     def test_measurement_with_c1_twirl(self):

--- a/test/unit/test_builders/test_gate_dependent_twirl_building.py
+++ b/test/unit/test_builders/test_gate_dependent_twirl_building.py
@@ -17,6 +17,7 @@ import pytest
 from qiskit.circuit import Parameter, QuantumCircuit
 
 from samplomatic import Twirl
+from samplomatic.annotations import GroupMode
 from samplomatic.builders import pre_build
 from samplomatic.exceptions import BuildError
 from samplomatic.pre_samplex import PreEmit
@@ -111,7 +112,7 @@ class TestGateDependetTwirling:
         with circuit.box([Twirl(dressing="right")]):
             circuit.noop(0, 1)
 
-        with pytest.raises(BuildError, match="Cannot use `GroupMode.LOCAL_C1`"):
+        with pytest.raises(BuildError, match=f"Cannot use `{GroupMode.LOCAL_C1}`"):
             pre_build(circuit)
 
     def test_overlapping_2q_gates_different_pairs(self):
@@ -124,7 +125,7 @@ class TestGateDependetTwirling:
         with circuit.box([Twirl(dressing="right")]):
             circuit.noop(0, 1, 2)
 
-        with pytest.raises(BuildError, match="Cannot use `GroupMode.LOCAL_C1`"):
+        with pytest.raises(BuildError, match=f"Cannot use `{GroupMode.LOCAL_C1}`"):
             pre_build(circuit)
 
     def test_measurement_with_c1_twirl(self):

--- a/test/unit/test_builders/test_gate_dependent_twirl_building.py
+++ b/test/unit/test_builders/test_gate_dependent_twirl_building.py
@@ -56,7 +56,7 @@ class TestGateDependetTwirling:
         assert any(n.twirl_gate is None and n.register_type == "pauli" for n in pre_emits)
 
     def test_overlapping_2q_gates_same_pair(self):
-        """Error when a local_c1 box has duplicate 2Q gates on the same qubits."""
+        """Error when a local_c1 box has duplicate two-qubit gates on the same qubits."""
         circuit = QuantumCircuit(2)
         with circuit.box([Twirl(group="local_c1", dressing="left")]):
             circuit.cx(0, 1)
@@ -66,11 +66,11 @@ class TestGateDependetTwirling:
         with circuit.box([Twirl(dressing="right")]):
             circuit.noop(0, 1)
 
-        with pytest.raises(BuildError, match="duplicate 2Q gates"):
+        with pytest.raises(BuildError, match="duplicate two-qubit gates"):
             pre_build(circuit)
 
     def test_overlapping_2q_gates_different_pairs(self):
-        """Error when a local_c1 box has 2Q gates on partially overlapping qubits."""
+        """Error when a local_c1 box has two-qubit gates on partially overlapping qubits."""
         circuit = QuantumCircuit(3)
         with circuit.box([Twirl(group="local_c1", dressing="left")]):
             circuit.cx(0, 1)
@@ -79,7 +79,7 @@ class TestGateDependetTwirling:
         with circuit.box([Twirl(dressing="right")]):
             circuit.noop(0, 1, 2)
 
-        with pytest.raises(BuildError, match="duplicate 2Q gates"):
+        with pytest.raises(BuildError, match="duplicate two-qubit gates"):
             pre_build(circuit)
 
     def test_measurement_with_c1_twirl(self):


### PR DESCRIPTION
## Summary

The `local_pauli` twirling mode uses `pauli` as its fallback, but enforces that only depth-1 boxes can be twirled even when they are Clifford. This PR relaxes this constraint on the Clifford part of a box, provided it is disjoint from any RZZ.

## Details and comments

See integration test for what is now allowed.

Also closes #397.