### PR TITLE
Fix hyperlink for `Tag` in docs

### DIFF
--- a/docs/api/samplomatic.annotations.rst
+++ b/docs/api/samplomatic.annotations.rst
@@ -20,4 +20,5 @@ Members of this module that were promoted to the namespace of the parent module.
 
    samplomatic.ChangeBasis
    samplomatic.InjectNoise
+   samplomatic.Tag
    samplomatic.Twirl


### PR DESCRIPTION
## Summary

Fixes the hyperlink to the `Tag` doc.

## Details and comments
