### PR TITLE
Change default of inject noise site to `"after"`

### DIFF
--- a/changelog.d/403.changed.md
+++ b/changelog.d/403.changed.md
@@ -1,0 +1,1 @@
+Changed the default value for the inject noise site for `generate_boxing_pass_manager`, `AddInjectNoise`, and `InjectNoise` from `"before"` to `"after"`.

--- a/samplomatic/annotations/inject_noise.py
+++ b/samplomatic/annotations/inject_noise.py
@@ -12,7 +12,6 @@
 
 """InjectNoise"""
 
-import warnings
 from enum import Enum
 from typing import Literal, TypeAlias
 
@@ -54,19 +53,10 @@ class InjectNoise(Annotation):
         self,
         ref: StrRef,
         modifier_ref: StrRef = "",
-        site: InjectionSiteLiteral | None = None,
+        site: InjectionSiteLiteral = "after",
     ):
         self.ref = ref
         self.modifier_ref = modifier_ref
-
-        if site is None:
-            warnings.warn(
-                "The default of the 'inject_noise_site' argument will be changed from "
-                "'before' to 'after' no sooner than version 0.21.0.",
-                FutureWarning,
-                stacklevel=1,
-            )
-            site = "before"
         self.site = InjectionSite(site)
 
     def __eq__(self, other):

--- a/samplomatic/transpiler/generate_boxing_pass_manager.py
+++ b/samplomatic/transpiler/generate_boxing_pass_manager.py
@@ -12,7 +12,6 @@
 
 """generate_boxing_pass_manager"""
 
-import warnings
 from typing import Literal
 
 from qiskit.transpiler import PassManager
@@ -65,7 +64,7 @@ def generate_boxing_pass_manager(
     inject_noise_strategy: Literal[
         "no_modification", "uniform_modification", "individual_modification"
     ] = "no_modification",
-    inject_noise_site: Literal["before", "after", None] = None,
+    inject_noise_site: Literal["before", "after"] = "after",
     remove_barriers: Literal[
         "immediately", "finally", "after_stratification", "never", True, False
     ] = "after_stratification",
@@ -256,15 +255,6 @@ def generate_boxing_pass_manager(
         remove_barriers = "immediately"
     elif remove_barriers is False:
         remove_barriers = "never"
-
-    if inject_noise_targets != "none" and inject_noise_site is None:
-        warnings.warn(
-            "The default of the 'inject_noise_site' argument will be changed from "
-            "'before' to 'after' no sooner than version 0.21.0.",
-            FutureWarning,
-            stacklevel=1,
-        )
-        inject_noise_site = "before"
 
     passes = []
     if remove_barriers == "immediately":

--- a/samplomatic/transpiler/passes/add_inject_noise.py
+++ b/samplomatic/transpiler/passes/add_inject_noise.py
@@ -13,7 +13,6 @@
 """AddInjectNoise"""
 
 import itertools
-import warnings
 from collections.abc import Callable
 from typing import Literal
 
@@ -70,7 +69,7 @@ class AddInjectNoise(TransformationPass):
         strategy: Literal[
             "no_modification", "uniform_modification", "individual_modification"
         ] = "no_modification",
-        site: Literal["before", "after", None] = None,
+        site: Literal["before", "after"] = "after",
         overwrite: bool = False,
         prefix_ref: str = "r",
         prefix_modifier_ref: str = "m",
@@ -82,15 +81,6 @@ class AddInjectNoise(TransformationPass):
         self.prefix_ref = prefix_ref
         self.prefix_modifier_ref = prefix_modifier_ref
         self.targets = targets
-
-        if site is None:
-            warnings.warn(
-                "The default of the 'inject_noise_site' argument will be changed from "
-                "'before' to 'after' no sooner than version 0.21.0.",
-                FutureWarning,
-                stacklevel=1,
-            )
-            site = "before"
         self.site = site
 
     def _get_ref(self, box_key: BoxKey) -> str:

--- a/test/integration/test_inject_noise_samples.py
+++ b/test/integration/test_inject_noise_samples.py
@@ -60,7 +60,7 @@ def make_circuits():
     yield (circuit, expected, pauli_lindblad_maps), "two_body_noise"
 
     circuit = QuantumCircuit(2)
-    with circuit.box([Twirl(), InjectNoise("my_noise")]):
+    with circuit.box([Twirl(), InjectNoise("my_noise", site="before")]):
         circuit.cx(0, 1)
 
     with circuit.box([Twirl(dressing="right")]):
@@ -73,7 +73,7 @@ def make_circuits():
     yield (circuit, expected, pauli_lindblad_maps), "xx_noise_permuted_before"
 
     circuit = QuantumCircuit(2)
-    with circuit.box([Twirl(), InjectNoise("my_noise", site="after")]):
+    with circuit.box([Twirl(), InjectNoise("my_noise")]):
         circuit.cx(0, 1)
 
     with circuit.box([Twirl(dressing="right")]):

--- a/test/unit/test_annotations/test_inject_noise.py
+++ b/test/unit/test_annotations/test_inject_noise.py
@@ -9,22 +9,14 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-import pytest
-
 from samplomatic.annotations import InjectionSite, InjectNoise
-
-
-def test_site_future_warning():
-    """Test default value of the ``site`` argument raises a futures warning."""
-    with pytest.warns(FutureWarning):
-        InjectNoise("my_ref")
 
 
 def test_construction():
     """Test that we can construct a InjectNoise."""
     inject_noise = InjectNoise("its_name")
     assert inject_noise.ref == "its_name"
-    assert inject_noise.site is InjectionSite.BEFORE
+    assert inject_noise.site is InjectionSite.AFTER
 
 
 def test_eq():
@@ -33,7 +25,7 @@ def test_eq():
     assert InjectNoise("ref") != "hey"
     assert InjectNoise("ref") != InjectNoise("another_ref")
     assert InjectNoise("ref") != InjectNoise("ref", "modifier_ref")
-    assert InjectNoise("ref") != InjectNoise("ref", site="after")
+    assert InjectNoise("ref") != InjectNoise("ref", site="before")
 
 
 def test_hash():
@@ -42,9 +34,9 @@ def test_hash():
     assert hash(InjectNoise("ref")) != hash("hey")
     assert hash(InjectNoise("ref")) != hash(InjectNoise("another_ref"))
     assert hash(InjectNoise("ref")) != hash(InjectNoise("ref", "modifier_ref"))
-    assert hash(InjectNoise("ref")) != hash(InjectNoise("ref", site="after"))
+    assert hash(InjectNoise("ref")) != hash(InjectNoise("ref", site="before"))
 
 
 def test_repr():
     """Test repr."""
-    assert repr(InjectNoise("ref")) == "InjectNoise(ref='ref', modifier_ref='', site='before')"
+    assert repr(InjectNoise("ref")) == "InjectNoise(ref='ref', modifier_ref='', site='after')"

--- a/test/unit/test_transpiler/test_generate_boxing_pass_manager.py
+++ b/test/unit/test_transpiler/test_generate_boxing_pass_manager.py
@@ -46,21 +46,6 @@ def test_remove_barriers_deprecation():
     assert pm_false.run(circuit) == pm_never.run(circuit)
 
 
-def test_inject_noise_site_deprecation():
-    """Test deprecated default values of the ``inject_noise_site`` option."""
-    circuit = QuantumCircuit(2)
-    circuit.cx(0, 1)
-    circuit.cx(0, 1)
-
-    with pytest.warns(FutureWarning):
-        pm_none = generate_boxing_pass_manager()
-
-    pm_before = generate_boxing_pass_manager(
-        inject_noise_strategy="uniform_modification", inject_noise_site="before"
-    )
-    assert pm_none.run(circuit) == pm_before.run(circuit)
-
-
 @pytest.mark.parametrize(
     "decomposition,measure_annotations", [("rzrx", "all"), ("rzsx", "change_basis")]
 )

--- a/test/unit/test_transpiler/test_passes/test_add_inject_noise.py
+++ b/test/unit/test_transpiler/test_passes/test_add_inject_noise.py
@@ -23,12 +23,6 @@ from samplomatic.transpiler.passes import AddInjectNoise
 from samplomatic.utils import get_annotation
 
 
-def test_site_future_warning():
-    """Test default value of the ``site`` argument raises a futures warning."""
-    with pytest.warns(FutureWarning):
-        AddInjectNoise()
-
-
 def test_no_modification_strategy():
     """Test `AddInjectNoise` with the ``"no_modification"`` strategy."""
     circuit = QuantumCircuit(2)


### PR DESCRIPTION
## Summary

In prepation for 0.21.0, updating the default value throughout the library.

## Details and comments

Undoes warnings added in #372 and #374.