### PR TITLE
Move QuantumProgram related tests to this repo

### DIFF
--- a/test/unit/test_quantum_program/test_chunk_timing.py
+++ b/test/unit/test_quantum_program/test_chunk_timing.py
@@ -1,0 +1,61 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import datetime
+
+import pytest
+
+from samplomatic.quantum_program import ChunkPart, ChunkSpan, ChunkTiming
+
+
+def _make_span(start_s: float, stop_s: float, size: int = 1) -> ChunkSpan:
+    """Build a ``ChunkSpan`` with a single ``ChunkPart``."""
+    epoch = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+    return ChunkSpan(
+        start=epoch + datetime.timedelta(seconds=start_s),
+        stop=epoch + datetime.timedelta(seconds=stop_s),
+        parts=[ChunkPart(idx_item=0, size=size)],
+    )
+
+
+class TestChunkTiming:
+    """Tests the ``ChunkTiming`` class."""
+
+    def test_len_and_iter(self):
+        """Supports len() and iteration over the wrapped spans."""
+        spans = [_make_span(0, 1), _make_span(1, 2), _make_span(2, 3)]
+        timing = ChunkTiming(spans)
+        assert len(timing) == 3
+        assert list(timing) == spans
+
+    def test_getitem_int(self):
+        """Integer indexing returns the corresponding ChunkSpan."""
+        spans = [_make_span(0, 1), _make_span(1, 2)]
+        timing = ChunkTiming(spans)
+        assert timing[0] == spans[0]
+        assert timing[1] == spans[1]
+
+    def test_getitem_slice(self):
+        """Slice indexing returns a new ChunkTiming."""
+        spans = [_make_span(i, i + 1) for i in range(4)]
+        sliced = ChunkTiming(spans)[1:3]
+        assert isinstance(sliced, ChunkTiming)
+        assert list(sliced) == spans[1:3]
+
+    def test_start_stop_duration(self):
+        """start, stop, and duration are derived from the spans."""
+        spans = [_make_span(10, 20, size=3), _make_span(25, 40, size=7)]
+        timing = ChunkTiming(spans)
+        epoch = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+        assert timing.start, epoch + datetime.timedelta(seconds=10)
+        assert timing.stop, epoch + datetime.timedelta(seconds=40)
+        assert timing.duration, pytest.approx(30.0)

--- a/test/unit/test_quantum_program/test_circuit_item.py
+++ b/test/unit/test_quantum_program/test_circuit_item.py
@@ -10,9 +10,10 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-import pytest
 import numpy as np
+import pytest
 from qiskit.circuit import Parameter, QuantumCircuit
+
 from samplomatic.quantum_program import CircuitItem
 
 
@@ -32,7 +33,7 @@ class TestCircuitItem:
             circuit, circuit_arguments=circuit_arguments, chunk_size=chunk_size
         )
         assert circuit_item.circuit == circuit
-        assert np.array_equal(circuit_item.circuit_arguments, circuit_arguments) == True
+        assert np.array_equal(circuit_item.circuit_arguments, circuit_arguments)
         assert circuit_item.chunk_size == chunk_size
         assert circuit_item.shape == expected_shape
 
@@ -45,8 +46,8 @@ class TestCircuitItem:
 
         circuit_item = CircuitItem(circuit)
         assert circuit_item.circuit == circuit
-        assert np.array_equal(circuit_item.circuit_arguments, expected_circuit_arguments) == True
-        assert circuit_item.chunk_size == None
+        assert np.array_equal(circuit_item.circuit_arguments, expected_circuit_arguments)
+        assert circuit_item.chunk_size is None
         assert circuit_item.shape == expected_shape
 
     def test_circuit_item_num_params_doesnt_match_circuit_arguments(self):

--- a/test/unit/test_quantum_program/test_circuit_item.py
+++ b/test/unit/test_quantum_program/test_circuit_item.py
@@ -1,0 +1,71 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import pytest
+import numpy as np
+from qiskit.circuit import Parameter, QuantumCircuit
+from samplomatic.quantum_program import CircuitItem
+
+
+class TestCircuitItem:
+    """Tests the ``CircuitItem`` class."""
+
+    def test_circuit_item(self):
+        """Test ``CircuitItem`` for a valid input."""
+        circuit = QuantumCircuit(1)
+        circuit.rx(Parameter("p"), 0)
+
+        circuit_arguments = np.array([[3], [4], [5]])
+        expected_shape = (3,)
+        chunk_size = 6
+
+        circuit_item = CircuitItem(
+            circuit, circuit_arguments=circuit_arguments, chunk_size=chunk_size
+        )
+        assert circuit_item.circuit == circuit
+        assert np.array_equal(circuit_item.circuit_arguments, circuit_arguments) == True
+        assert circuit_item.chunk_size == chunk_size
+        assert circuit_item.shape == expected_shape
+
+    def test_circuit_item_no_params(self):
+        """Test ``CircuitItem`` when there are no parameters."""
+        circuit = QuantumCircuit(1)
+
+        expected_circuit_arguments = np.array([])
+        expected_shape = ()
+
+        circuit_item = CircuitItem(circuit)
+        assert circuit_item.circuit == circuit
+        assert np.array_equal(circuit_item.circuit_arguments, expected_circuit_arguments) == True
+        assert circuit_item.chunk_size == None
+        assert circuit_item.shape == expected_shape
+
+    def test_circuit_item_num_params_doesnt_match_circuit_arguments(self):
+        """Test ``CircuitItem`` raises if the number of circuit parameters doesn't match shape.
+
+        Test that ``CircuitItem`` raises an error if the number of circuit parameters
+        doesn't match the shape of the circuit arguments.
+        """
+        circuit = QuantumCircuit(1)
+        circuit.rx(Parameter("p"), 0)
+
+        circuit_arguments = np.array([[3, 10], [4, 11], [5, 12]])
+        with pytest.raises(ValueError, match=r"match the number of parameters"):
+            CircuitItem(circuit, circuit_arguments=circuit_arguments)
+
+    def test_circuit_item_no_circuit_arguments_for_parametric_circuit(self):
+        """Test ``CircuitItem`` raises if circuit has parameters but unset ``circuit_arguments``."""
+        circuit = QuantumCircuit(1)
+        circuit.rx(Parameter("p"), 0)
+
+        with pytest.raises(ValueError, match=r"no 'circuit_arguments'"):
+            CircuitItem(circuit)

--- a/test/unit/test_quantum_program/test_samplex_item.py
+++ b/test/unit/test_quantum_program/test_samplex_item.py
@@ -1,0 +1,189 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+import numpy as np
+import pytest
+from qiskit.circuit import Parameter, QuantumCircuit
+from qiskit.quantum_info import PauliLindbladMap
+
+from samplomatic import InjectNoise, Twirl, build
+from samplomatic.quantum_program import SamplexItem
+
+
+class TestSamplexItem:
+    """Tests the ``SamplexItem`` class."""
+
+    def test_samplex_item(self):
+        """Test ``SamplexItem`` for a valid input."""
+        circuit = QuantumCircuit(2)
+        with circuit.box(annotations=[Twirl()]):
+            circuit.rx(Parameter("p"), 0)
+            circuit.cx(0, 1)
+        with circuit.box(annotations=[Twirl()]):
+            circuit.measure_all()
+
+        template_circuit, samplex = build(circuit)
+
+        parameter_values = np.array([[[1], [2]], [[3], [4]], [[5], [6]]])
+        shape = (30, 1, 2)
+
+        samplex_item = SamplexItem(
+            template_circuit,
+            samplex,
+            samplex_arguments={"parameter_values": parameter_values},
+            shape=shape,
+            chunk_size=7,
+        )
+        assert samplex_item.samplex == samplex
+        assert samplex_item.circuit == template_circuit
+        assert samplex_item.chunk_size == 7
+        assert samplex_item.shape == (30, 3, 2)
+        assert np.array_equal(samplex_item.samplex_arguments["parameter_values"], parameter_values)
+
+    def test_samplex_item_shape_not_broadcastable(self):
+        """Test raising an error when the samplex shape does not match the parameter values."""
+        circuit = QuantumCircuit(2)
+        with circuit.box(annotations=[Twirl()]):
+            circuit.rx(Parameter("p"), 0)
+            circuit.cx(0, 1)
+        with circuit.box(annotations=[Twirl()]):
+            circuit.measure_all()
+
+        template_circuit, samplex = build(circuit)
+
+        parameter_values = np.array([[[1], [2]], [[3], [4]], [[5], [6]]])
+        shape = (30, 2, 2)
+
+        with pytest.raises(ValueError, match=r"must be broadcastable"):
+            SamplexItem(
+                template_circuit,
+                samplex,
+                samplex_arguments={"parameter_values": parameter_values},
+                shape=shape,
+            )
+
+    def test_samplex_item_no_params(self):
+        """Test ``SamplexItem`` when there are no parameters."""
+        circuit = QuantumCircuit(2)
+        with circuit.box(annotations=[Twirl()]):
+            circuit.cx(0, 1)
+        with circuit.box(annotations=[Twirl()]):
+            circuit.measure_all()
+
+        template_circuit, samplex = build(circuit)
+
+        samplex_item = SamplexItem(template_circuit, samplex)
+        assert samplex_item.samplex == samplex
+        assert samplex_item.circuit == template_circuit
+        assert samplex_item.chunk_size is None
+        assert samplex_item.shape == ()
+
+    def test_samplex_item_num_params_doesnt_match_circuit_arguments(self):
+        """Test raising if number of circuit parameters doesn't match the shape.
+
+        Test that ``SamplexItem`` raises an error if the number of circuit parameters
+        doesn't match the shape of the samplex arguments.
+        """
+        circuit = QuantumCircuit(2)
+        with circuit.box(annotations=[Twirl()]):
+            circuit.rx(Parameter("p"), 0)
+            circuit.cx(0, 1)
+        with circuit.box(annotations=[Twirl()]):
+            circuit.measure_all()
+
+        template_circuit, samplex = build(circuit)
+
+        parameter_values = np.array([[3, 10], [4, 11], [5, 12]])
+        with pytest.raises(ValueError, match=r"expects an array ending with shape"):
+            SamplexItem(
+                template_circuit, samplex, samplex_arguments={"parameter_values": parameter_values}
+            )
+
+    def test_samplex_item_no_samplex_arguments_for_parametric_circuit(self):
+        """Test raising if the circuit has parameters but ``samplex_arguments`` is unset.
+
+        Test that ``SamplexItem`` raises an error if the circuit has parameters
+        but the ``samplex_arguments`` parameter is unset.
+        """
+        circuit = QuantumCircuit(2)
+        with circuit.box(annotations=[Twirl()]):
+            circuit.rx(Parameter("p"), 0)
+            circuit.cx(0, 1)
+        with circuit.box(annotations=[Twirl()]):
+            circuit.measure_all()
+
+        template_circuit, samplex = build(circuit)
+
+        with pytest.raises(ValueError, match=r"parameter values to use during sampling"):
+            SamplexItem(template_circuit, samplex)
+
+    def test_samplex_item_with_noise(self):
+        """Test ``SamplexItem`` with noise annotations."""
+        circuit = QuantumCircuit(2)
+        with circuit.box(annotations=[Twirl(), InjectNoise(ref="r0", site="after")]):
+            circuit.rx(Parameter("p"), 0)
+            circuit.cx(0, 1)
+        with circuit.box(annotations=[Twirl(), InjectNoise(ref="r1", site="after")]):
+            circuit.measure_all()
+
+        template_circuit, samplex = build(circuit)
+
+        parameter_values = np.array([[[1], [2]], [[3], [4]], [[5], [6]]])
+        pauli_lindblad_maps = {
+            "r0": PauliLindbladMap.from_list([("IX", 0.04), ("XX", 0.05)]),
+            "r1": PauliLindbladMap.from_list([("XI", 0.02), ("IZ", 0.035)]),
+        }
+
+        samplex_item = SamplexItem(
+            template_circuit,
+            samplex,
+            samplex_arguments={
+                "parameter_values": parameter_values,
+                "pauli_lindblad_maps": pauli_lindblad_maps,
+            },
+        )
+        assert samplex_item.samplex == samplex
+        assert samplex_item.circuit == template_circuit
+        assert samplex_item.chunk_size is None
+        assert samplex_item.shape == (3, 2)
+        assert np.array_equal(samplex_item.samplex_arguments["parameter_values"], parameter_values)
+        assert samplex_item.samplex_arguments["pauli_lindblad_maps.r0"] == pauli_lindblad_maps["r0"]
+        assert samplex_item.samplex_arguments["pauli_lindblad_maps.r1"] == pauli_lindblad_maps["r1"]
+
+    def test_samplex_item_missing_pauli_lindblad_map_in_samplex_arguments(self):
+        """Test raising when a noise annotation does not contain a Pauli-Lindblad map.
+
+        Test that ``SamplexItem`` raises an error when the samplex arguments don't contain
+        a Pauli-Lindblad map for a noise annotation.
+        """
+        circuit = QuantumCircuit(2)
+        with circuit.box(annotations=[Twirl(), InjectNoise(ref="r0", site="after")]):
+            circuit.rx(Parameter("p"), 0)
+            circuit.cx(0, 1)
+        with circuit.box(annotations=[Twirl(), InjectNoise(ref="r1", site="after")]):
+            circuit.measure_all()
+
+        template_circuit, samplex = build(circuit)
+
+        parameter_values = np.array([[[1], [2]], [[3], [4]], [[5], [6]]])
+        pauli_lindblad_maps = {"r0": PauliLindbladMap.from_list([("IX", 0.04), ("XX", 0.05)])}
+
+        with pytest.raises(ValueError, match=r"pauli_lindblad_maps.r1"):
+            SamplexItem(
+                template_circuit,
+                samplex,
+                samplex_arguments={
+                    "parameter_values": parameter_values,
+                    "pauli_lindblad_maps": pauli_lindblad_maps,
+                },
+            )


### PR DESCRIPTION
## Summary

Related to: #396

As `QuantumProgram` was moved, some tests that involved some of the items moved are currently in `qiskit_ibm_runtime`, effectively focused on testing those now `samplomatic` items. This PR moves those tests to this repo.

## Details and comments

See also https://github.com/Qiskit/qiskit-ibm-runtime/pull/3206#issuecomment-5430872667 (this is tackling the next steps after the PR got merged).